### PR TITLE
Use projectId in addition to API key when starting airbrake client.

### DIFF
--- a/components/utils/src/logging.js
+++ b/components/utils/src/logging.js
@@ -48,7 +48,7 @@ module.exports = function (logsSettings) {
     });
   }
   if (logsSettings.airbrake.active) {
-    airbrake = require('airbrake').createClient(logsSettings.airbrake.key);
+    airbrake = require('airbrake').createClient(logsSettings.airbrake.projectId, logsSettings.airbrake.key);
     airbrake.handleExceptions();
   }
 


### PR DESCRIPTION
airbrake was upgraded from v0.3.8 to v.1.2.x during the upgrade to Node v6.

`airbrake.createClient('API_KEY')` has a new signature `airbrake.createClient('PROJECT_ID', 'API_KEY')`

Therefore, the config file must include the field `logs.airbrake.projectId`