### PR TITLE
Fix/account tests

### DIFF
--- a/components/api-server/test/account.test.js
+++ b/components/api-server/test/account.test.js
@@ -1,5 +1,6 @@
 /*global describe, before, beforeEach, it */
 
+require('./test-helpers');
 var helpers = require('./helpers'),
     server = helpers.dependencies.instanceManager,
     async = require('async'),

--- a/components/api-server/test/test-helpers.js
+++ b/components/api-server/test/test-helpers.js
@@ -1,0 +1,3 @@
+// @flow
+
+process.env.NODE_ENV = 'test';


### PR DESCRIPTION
Through this PR, we want to avoid running account tests without NODE_ENV=test, since it is required when mocking a server.

It's a source of errors appearing in [Airbrake](https://pryv.airbrake.io/projects/95887/groups/2094958092787185469).
