### PR TITLE
Fix events.getAttachment error message when used with auth query param

### DIFF
--- a/components/api-server/src/routes/events.js
+++ b/components/api-server/src/routes/events.js
@@ -60,7 +60,10 @@ module.exports = function(
   function retrieveAccessFromReadToken(req, res, next) {
     if (req.query.auth) {
       // forbid using access tokens in the URL
-      delete req.context.accessToken;
+      return next(errors.invalidAccessToken(
+        'Query parameter "auth" is forbidden here, ' +
+        'please use the "readToken" instead ' +
+        'or provide the auth token in "Authorization" header.'));
     }
 
     if (! req.query.readToken) { return next(); }


### PR DESCRIPTION
Fix #88 

Usage of auth query parameter to get an attachment is forbidden by the API, but the corresponding error message was not specific enough and thus confusing for the users.

This PR fix the error message by early-returning a specific message.