### PR TITLE
Bugfix: delete root stream mergeEventsWithParent

### DIFF
--- a/components/api-server/src/methods/streams.js
+++ b/components/api-server/src/methods/streams.js
@@ -287,6 +287,13 @@ module.exports = function (api, userStreamsStorage, userEventsStorage, userEvent
         });
       },
       function checkIfLinkedEventsExist(stepDone) {
+        if(params.mergeEventsWithParent === true && parentId == null) {
+          return stepDone(errors.invalidOperation(
+            'Deleting a root stream with mergeEventsWithParent=true is rejected ' +
+            'since there is no parent stream to merge linked events in.',
+            {streamId: params.id}));
+        }
+        
         userEventsStorage.find(context.user, {streamId: {$in: streamAndDescendantIds}},
           {limit: 1}, function (err, events) {
             if (err) {

--- a/components/api-server/test/streams.test.js
+++ b/components/api-server/test/streams.test.js
@@ -672,6 +672,23 @@ describe('streams', function () {
       ],
       done );
     });
+    
+    it('must reject the deletion of a root stream with mergeEventsWithParent=true', function (done) {
+      var id = testData.streams[0].id;
+      async.series([
+        storage.updateOne.bind(storage, user, {id: id}, {trashed: true}), function deleteStream(stepDone) {
+          request.del(path(testData.streams[0].id)).query({mergeEventsWithParent: true})
+            .end(function (res) {
+              validation.checkError(res, {
+                status: 400,
+                id: ErrorIds.InvalidOperation,
+                data: {streamId: id}
+              }, stepDone);
+            });
+        }
+      ],
+      done );
+    });
 
     it('must reassign the linked events to the deleted stream\'s parent when specified', function (done) {
       var parentStream = testData.streams[0],


### PR DESCRIPTION
Fix #44.

Deletion of root streams allows to set mergeEventsWithParent to true, which results in a successful stream delete and updates of the linked events' ids to null (since parentId=null for root stream).

This is fixed by throwing an invalid-operation error in such case.

Another proposed solution was to delete the events if no parent stream is found for the merge, which I like less. If clients set mergeEventsWithParent to true, it probably means that they care to keep the events, thus my preference to reject the deletion instead of deleting the events.

Please tell me in the review if you agree with my point of view or prefer the other solution.