### PR TITLE
Blacklist json parsing errors from Airbrake

### DIFF
--- a/components/api-server/src/middleware/errors.js
+++ b/components/api-server/src/middleware/errors.js
@@ -1,24 +1,22 @@
-'use strict';
 // @flow
 
-var errors = require('components/errors'),
-    APIError = errors.APIError,
-    ErrorIds = errors.ErrorIds,
-    errorHandling = errors.errorHandling,
-    setCommonMeta = require('../methods/helpers/setCommonMeta');
+const errors = require('components/errors');
+const errorsFactory = errors.factory;
+const APIError = errors.APIError;
+const errorHandling = errors.errorHandling;
+const setCommonMeta = require('../methods/helpers/setCommonMeta');
 
 /** Error route handling.
  */
-module.exports = function produceHandleErrorMiddleware(logging: any) {
-  var logger = logging.getLogger('routes');
+function produceHandleErrorMiddleware(logging: any) {
+  const logger = logging.getLogger('routes');
 
   // NOTE next is not used, since the request is terminated on all errors. 
   /*eslint-disable no-unused-vars*/
   return function handleError(error, req: express$Request, res: express$Response, next: () => void) {
     if (! (error instanceof APIError) && error.status) {
       // it should be coming from Express' bodyParser: just wrap the error
-      error = new APIError(ErrorIds.InvalidRequestStructure, error.message,
-          {httpStatus: error.status});
+      error = errorsFactory.invalidRequestStructure(error.message);
     }
 
     errorHandling.logError(error, req, logger);
@@ -28,5 +26,7 @@ module.exports = function produceHandleErrorMiddleware(logging: any) {
         setCommonMeta(
           {error: errorHandling.getPublicErrorData(error)}));
   };
-};
+}
+
+module.exports = produceHandleErrorMiddleware;
 module.exports.injectDependencies = true;


### PR DESCRIPTION
Json parsing errors were still poping in Airbrake because errors middleware was bypassing the Airbrake filtering.

This is fixed by making errors middleware use the errors factory (which is setting the 'dontNotifyAirbrake' flag).