### PR TITLE
Airbrake/missing-host

### DIFF
--- a/components/errors/src/factory.js
+++ b/components/errors/src/factory.js
@@ -120,8 +120,10 @@ factory.itemAlreadyExists = function (
 factory.missingHeader = function (headerName: string, status: ?number) {
   return new APIError(
     ErrorIds.MissingHeader, 
-    'Missing expected header "' + headerName + '"',
-    {httpStatus: status || 400}
+    'Missing expected header "' + headerName + '"', {
+      httpStatus: status || 400,
+      dontNotifyAirbrake: true
+    }
   );
 };
 


### PR DESCRIPTION
Web crawlers are trying to GET our robots.txt file but do not even provide the host parameter in the headers (also they appear as MSIE 5...).

The API error we throw at the client is fine but we do not want to see it in Airbrake.