### PR TITLE
Remove version flag for pryv-cli delete.

### DIFF
--- a/components/pryvuser-cli/src/app.js
+++ b/components/pryvuser-cli/src/app.js
@@ -31,7 +31,6 @@ function setupCommander(): any {
   const program = require('commander');
 
   program
-    .version('1.3.0')
     .option('-n, --no-interaction', 'Runs without prompting for confirmation.');
 
   // Register all subcommands in the list below. The files must export a class


### PR DESCRIPTION
The version was hardcoded to 1.3.0 and does not make any sense since we rely on the docker container tag.