### PR TITLE
Improve change email call.

### DIFF
--- a/components/api-server/src/methods/account.js
+++ b/components/api-server/src/methods/account.js
@@ -173,7 +173,7 @@ module.exports = function (api, usersStorage, passwordResetRequestsStorage,
           // for some reason register returns error message within res.body
           if (res != null && res.body != null && res.body.message != null) {
             errMsg += res.body.message;
-          } else if (err != null && err.message) {
+          } else if (err != null && err.message != null) {
             errMsg += err.message;
           }
           return next(errors.invalidOperation(errMsg, {email: newEmail}, err));


### PR DESCRIPTION
Fixes #178 

Through this PR, we reverse the order for updating emails between core and register, by first trying to update register and adapt the error thrown by core.

We thus avoid the situation where core was able to perform an update with an email already taken by another user (on another core) before asking register, which was throwing an error (500) after the update was already done on core.

This does not prevent sync issues between core and register (for example if register crashes after udpating the email and before answering to core).

See the related PR on register: https://github.com/pryv/service-register/pull/76