### PR TITLE
Throw consistent error for trashed hfs events.

### DIFF
--- a/components/hfs-server/src/web/op/store_series_batch.js
+++ b/components/hfs-server/src/web/op/store_series_batch.js
@@ -127,7 +127,10 @@ class EventMetaDataCache {
     const seriesMeta = await this.getSeriesMeta(eventId);
 
     if (seriesMeta.isTrashedOrDeleted()) {
-      throw errors.forbidden('Access to trashed or deleted series is forbidden');
+      throw errors.invalidOperation(
+        `The referenced event "${eventId}" is trashed.`,
+        {trashedReference: 'eventId'}
+      );
     }
 
     if (! seriesMeta.canWrite()) 

--- a/components/hfs-server/src/web/op/store_series_data.js
+++ b/components/hfs-server/src/web/op/store_series_data.js
@@ -37,7 +37,10 @@ async function storeSeriesData(ctx: Context,
 
   // Trashed or Deleted: Abort.
   if (seriesMeta.isTrashedOrDeleted()) {
-    throw errors.forbidden('Access to trashed or deleted series is forbidden');
+    throw errors.invalidOperation(
+      `The referenced event "${eventId}" is trashed.`,
+      {trashedReference: 'eventId'}
+    );
   }
   
   // No access permission: Abort.

--- a/components/hfs-server/test/acceptance/store_data.test.js
+++ b/components/hfs-server/test/acceptance/store_data.test.js
@@ -358,7 +358,7 @@ describe('Storing data in a HF series', function() {
         });
     });
 
-    it('[UD2C] trashed event cannot be accessed', async () => {
+    it('[UD2C] trashed event cannot be written to', async () => {
       // This is visible if after moving the "timestamp" sugar is valid
       
       // 1 - Create an event with some values
@@ -390,12 +390,12 @@ describe('Storing data in a HF series', function() {
             [newEventTime + 6, 6]]
         });
 
-      assert.strictEqual(result2.status, 403);
+      assert.strictEqual(result2.status, 400);
       const error = result2.body.error;
-      assert.strictEqual(error.id, 'forbidden');
-      assert.strictEqual(error.message, 'Access to trashed or deleted series is forbidden');
+      assert.strictEqual(error.id, 'invalid-operation');
       assert.typeOf(error.message, 'string');
-   
+      assert.strictEqual(error.message, `The referenced event "${result.event.id}" is trashed.`);
+      assert.deepEqual(error.data, {trashedReference: 'eventId'});
     });
 
     it('[ZTG6] deleted events deletes series', async function() {


### PR DESCRIPTION
The error thrown when trying to add data points to a trashed HFS event should be similar to the one we throw when trying to add events in a trashed stream, see:
- http://api.pryv.com/reference/#create-event
- https://github.com/pryv/service-core/blob/release-1.4/components/api-server/src/methods/events.js#L595

So: invalidOperation (400) with the following message: `The referenced event "${eventId}" is trashed.`