### PR TITLE
[Do not merge] set default config as local reg and put dumb customAuthStepFn

### DIFF
--- a/components/api-server/config/development.json
+++ b/components/api-server/config/development.json
@@ -7,7 +7,7 @@
       "enabled": false
     },
     "register": {
-      "url": "https://reg.pryv.io"
+      "url": "http://localhost:8080"
     }
   }, 
   "tcpMessaging": {

--- a/components/api-server/config/production.json
+++ b/components/api-server/config/production.json
@@ -33,7 +33,7 @@
   },
   "services": {
     "register": {
-      "url": "https://reg.pryv.io"
+      "url": "http://localhost:8080"
     },
     "email": {
       "welcomeTemplate": "welcome-email",

--- a/custom-extensions/customAuthStepFn.js
+++ b/custom-extensions/customAuthStepFn.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+module.exports = function(context, callback) {
+  // do whatever is needed here (check LDAP, custom DB, etc.)
+  console.log('hi with', JSON.stringify(context, null, 2));
+  fs.writeFileSync('YOYOYOYO.txt', JSON.stringify(context,null,2));
+  callback();
+};


### PR DESCRIPTION
Here is a runnable customAuth. Boot local reg, then boot local api-server.

Setup:

### 1. create user

```
curl -i -X POST -H 'Content-Type: application/json' -d '{
	"appid":"default",
	"hosting":"local-api-server",
	"username":"testuser",
	"password":"testuser",
	"email":"joseph-brenner@pryv.me",
	"invitationtoken":"o3in4o2",
	"languageCode":"en",
	"referer":"hospital-A"}' http://localhost:8080/user
```

### 2 Login

```
curl -i -X POST -H 'Origin: https://l.rec.la' -H 'Content-Type: application/json' -d '{"username":"testuser","password":"testuser","appId":"my-app-id"}' "http://localhost:5000/testuser/auth/login"
```

### 3. Make API call with obtained token

```
curl -i "http://localhost:5000/testuser/events?auth=ck2ca11b90002hfpvagr7v4xp"
```