### PR TITLE
Fix: Accesses.get gives inexact result when accesses have permissions on unexisting/deleted streams.

### DIFF
--- a/components/api-server/test/accesses-app.test.js
+++ b/components/api-server/test/accesses-app.test.js
@@ -99,6 +99,22 @@ describe('accesses (app)', function () {
       createdBy: 'test',
       modified: timestamp.now(),
       modifiedBy: 'test'
+    },
+    {
+      id: 'shared_B',
+      token: 'shared_B_token',
+      name: 'Shared access B (with permission on unexisting stream)',
+      type: 'shared',
+      permissions: [
+        {
+          streamId: 'idonotexist',
+          level: 'read'
+        }
+      ],
+      created: timestamp.now(),
+      createdBy: 'test',
+      modified: timestamp.now(),
+      modifiedBy: 'test'
     }
   ];
   const user = testData.users[0];

--- a/components/model/src/accessLogic.js
+++ b/components/model/src/accessLogic.js
@@ -85,7 +85,6 @@ const accessLogic = module.exports = {
       }
 
       var expandedPerm = id === perm.streamId ? perm : _.extend(_.clone(perm), {streamId: id});
-
       this._registerStreamPermission(expandedPerm);
     }.bind(this));
   },
@@ -166,12 +165,12 @@ const accessLogic = module.exports = {
     
     // assert: candidate.isShared()
 
+    candidate.loadPermissions(this._cachedStreams);
+
     if (! hasPermissions(this) || ! hasPermissions(candidate)) {
       // can only manage shared accesses with permissions
       return false;
     }
-
-    candidate.loadPermissions(this._cachedStreams);
 
     // Can candidate access streams that `this` cannot? Does it elevate the 
     // permissions on common streams? If yes, abort. 
@@ -247,5 +246,8 @@ function isLowerLevel(permissionLevelA, permissionLevelB) {
 }
 
 function hasPermissions(access) {
-  return access.permissions && access.permissions.length > 0;
+
+  return access.permissions && access.permissions.length > 0 &&
+    ((access.streamPermissions && access.streamPermissions.length > 0)
+      || (access.tagPermissions && access.tagPermissions.length > 0));
 }


### PR DESCRIPTION
Candidate accesses with no permissions (empty candidate.permissions) were correctly handled.

However, accesses with permissions on unexisting/deleted streams will have non-empty candidate.permissions but empty candidate.streamPermissions and candidate.tagPermissions.

We now also check if these two sets are empty, in such case 'canManageAccess' returns 'false'. (It was previously returning 'true').

Fixes #217 