### PR TITLE
Tracing/clean and improve

### DIFF
--- a/components/middleware/src/requestTrace.js
+++ b/components/middleware/src/requestTrace.js
@@ -7,14 +7,50 @@
 'use strict'; 
 // @flow
 
+const inspect = require('util').inspect;
 const morgan = require('morgan');
 const { getLogger } = require('@pryv/boiler');
+
+const QUERY_PARAMS_WHITELIST = [
+  'fromTime', 'toTime', 'streams', 'tags', 'types', 'running', 'sortAscending', 'skip', 'limit', 'state', 'modifiedSince', 'includeDeletions',
+  'includeHistory',
+  'fromDeltaTime', 'toDeltaTime',
+  'parentId', 'state', 'includeDeletionsSince',
+  'includeExpired', 'includeDeletions',
+  'requestingAppId', 'deviceName', 'requestedPermissions',
+  'accessId', 'fromTime', 'toTime', 'status', 'ip', 'httpVerb', 'resource', 'errorId',
+];
+const allowedMap = {}
+QUERY_PARAMS_WHITELIST.map(param => {
+  allowedMap[param] = true;
+});
+
+morgan.token('cleanQuery', function (req) {
+  if (req.query == null) return '-'
+  let cleanQuery = '';
+
+  for (const [key, value] of Object.entries(req.query)) {
+    if (allowedMap[key]) {
+      cleanQuery += key + '=' + inspect(value) + '&';
+    }
+  }
+  cleanQuery = cleanQuery.slice(0, cleanQuery.length - 1);
+  return cleanQuery;
+});
+
+morgan.token('path', function (req) {
+  return req.path;
+});
 
 module.exports = function (express: any) {
   const logger = getLogger('request-trace');
   const morganLoggerStreamWrite = (msg: string) => logger.info(msg);
   
-  return morgan('combined', {stream: {
-    write: morganLoggerStreamWrite
-  }});
+  // based on 'combined', but with whitelisted query params: https://www.npmjs.com/package/morgan#combined
+  return morgan(':remote-addr - [:date[clf]] ":method :path :cleanQuery HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"', 
+    {
+      stream: {
+        write: morganLoggerStreamWrite
+    },
+  });
 };


### PR DESCRIPTION
to check after audit release.

- Current issue: readToken appears in logs with full path, which is a complete data leak if the username is included in the path.
- Other goals: improve tracing for what we need so we can have manage performance evaluation based on logs

stopping this, we'll do it in NGINX - so it's common to all services