### PR TITLE
Fixing promise in handler warning

### DIFF
--- a/components/api-server/src/methods/events.js
+++ b/components/api-server/src/methods/events.js
@@ -999,10 +999,11 @@ module.exports = function (
 
     const validator = typeRepo.validator();
     validator.validate(eventType, content)
-      .then((newContent) => {
+      .then(function (newContent) {
         // Store the coerced value. 
         context.content.content = newContent; 
         next();
+        return null;
       })
       .catch(
         (err) => next(errors.invalidParametersFormat(


### PR DESCRIPTION
Fixing: 

```
stderr: (node:31943) Warning: a promise was created in a handler at home/perki/service-core/dist/components/api-server/src/methods/events.js:1010:14 but was not returned from it, see http://goo.gl/rRqMUw
    at Function.Promise.fromNode.Promise.fromCallback (/home/perki/service-core/dist/node_modules/bluebird/js/release/promise.js:206:9)
```