### PR TITLE
Fix/platform users index integrity

### DIFF
--- a/components/api-server/src/methods/account.js
+++ b/components/api-server/src/methods/account.js
@@ -14,17 +14,16 @@ const methodsSchema = require('../schema/accountMethods');
 
 const { getConfig } = require('@pryv/boiler');
 const { pubsub } = require('messages');
-const { getStorageLayer } = require('storage');
+const { getStorageLayer } = require('storage');
 const {getPlatform } = require('platform');
 
 const { setAuditAccessId, AuditAccessIds } = require('audit/src/MethodContextUtils');
 
-const Registration = require('business/src/auth/registration'),
-  ErrorMessages = require('errors/src/ErrorMessages'),
-  ErrorIds = require('errors').ErrorIds,
-  { getUsersRepository, UserRepositoryOptions} = require('business/src/users');
+const ErrorMessages = require('errors/src/ErrorMessages');
+const ErrorIds = require('errors').ErrorIds;
+const { getUsersRepository, UserRepositoryOptions} = require('business/src/users');
 const SystemStreamsSerializer = require('business/src/system-streams/serializer');
-  /**
+/**
  * @param api
  */
 module.exports = async function (api) {
@@ -35,11 +34,11 @@ module.exports = async function (api) {
   const passwordResetRequestsStorage = storageLayer.passwordResetRequests;
   const platform = await getPlatform();
 
-  var emailSettings = servicesSettings.email,
-    requireTrustedAppFn = commonFns.getTrustedAppCheck(authSettings);
+  const emailSettings = servicesSettings.email;
+  const requireTrustedAppFn = commonFns.getTrustedAppCheck(authSettings);
 
   // initialize service-register connection
-  const usersRepository = await getUsersRepository(); 
+  const usersRepository = await getUsersRepository();
 
   // RETRIEVAL
 
@@ -55,12 +54,12 @@ module.exports = async function (api) {
         return next(errors.unexpectedError(err));
       }
     });
-  
+
 
   // UPDATE
 
   api.register('account.update',
-    commonFns.basicAccessAuthorizationCheck,  
+    commonFns.basicAccessAuthorizationCheck,
     commonFns.getParamsValidation(methodsSchema.update.params),
     validateThatAllFieldsAreEditable,
     updateDataOnPlatform,
@@ -71,11 +70,11 @@ module.exports = async function (api) {
 
   /**
    * Validate if given parameters are allowed for the edit
-   * 
-   * @param {*} context 
-   * @param {*} params 
-   * @param {*} result 
-   * @param {*} next 
+   *
+   * @param {*} context
+   * @param {*} params
+   * @param {*} result
+   * @param {*} next
    */
   function validateThatAllFieldsAreEditable (context, params, result, next) {
     const editableAccountMap: Map<string, SystemStream> = SystemStreamsSerializer.getEditableAccountMap();
@@ -88,7 +87,7 @@ module.exports = async function (api) {
           { field: streamId }
         ));
       }
-    })
+    });
     next();
   }
   // CHANGE PASSWORD
@@ -126,7 +125,7 @@ module.exports = async function (api) {
     sendPasswordResetMail,
     setAuditAccessId(AuditAccessIds.PASSWORD_RESET_REQUEST));
 
-  
+
 
   function generatePasswordResetRequest(context, params, result, next) {
     const username = context.user.username;
@@ -218,24 +217,23 @@ module.exports = async function (api) {
   }
 
   async function updateDataOnPlatform (context, params, result, next) {
-    
+
     try {
       const editableAccountMap: Map<string, SystemStream> = SystemStreamsSerializer.getEditableAccountMap();
-      
+
       const operations: Array<{}> = [];
       for (const [key, value] of Object.entries(params.update)) {
         // get previous value of the field;
         const previousValue = await usersRepository.getOnePropertyValue(context.user.id, key);
 
         operations.push({
-            action: 'update',
-            key,
-            value,
-            previousValue,
-            isUnique: editableAccountMap[SystemStreamsSerializer.addCorrectPrefixToAccountStreamId(key)].isUnique,
-            isActive: true
-          }
-        );
+          action: 'update',
+          key,
+          value,
+          previousValue,
+          isUnique: editableAccountMap[SystemStreamsSerializer.addCorrectPrefixToAccountStreamId(key)].isUnique,
+          isActive: true
+        });
       }
 
       await platform.updateUserAndForward(context.user.username, operations);
@@ -248,7 +246,7 @@ module.exports = async function (api) {
 
   async function updateAccount(context, params, result, next) {
     try {
-      const accessId = (context.access?.id) ? context.access.id : UserRepositoryOptions.SYSTEM_USER_ACCESS_ID
+      const accessId = (context.access?.id) ? context.access.id : UserRepositoryOptions.SYSTEM_USER_ACCESS_ID;
       await usersRepository.updateOne(
         context.user,
         params.update,
@@ -270,10 +268,10 @@ module.exports = async function (api) {
 
   /**
    * Build response body for the account update
-   * @param {*} context 
-   * @param {*} params 
-   * @param {*} result 
-   * @param {*} next 
+   * @param {*} context
+   * @param {*} params
+   * @param {*} result
+   * @param {*} next
    */
   async function buildResultData (context, params, result, next) {
     Object.keys(params.update).forEach(key => {

--- a/components/api-server/src/methods/events.js
+++ b/components/api-server/src/methods/events.js
@@ -5,30 +5,23 @@
  * Proprietary and confidential
  */
 
-const cuid = require('cuid');
 const utils = require('utils');
 const errors = require('errors').factory;
 const async = require('async');
-const bluebird = require('bluebird');
 const fs = require('fs');
 const commonFns = require('./helpers/commonFunctions');
 const methodsSchema = require('../schema/eventsMethods');
 const eventSchema = require('../schema/event');
 const timestamp = require('unix-timestamp');
 const _ = require('lodash');
-const SetFileReadTokenStream = require('./streams/SetFileReadTokenStream');
-const SetSingleStreamIdStream = require('./streams/SetSingleStreamIdStream');
-const addTagsStream = require('./streams/AddTagsStream');
 
-const { getMall, streamsUtils } = require('mall');
+const { getMall } = require('mall');
 const SystemStreamsSerializer = require('business/src/system-streams/serializer');
-const Registration = require('business/src/auth/registration');
 const { getUsersRepository } = require('business/src/users');
 const ErrorIds = require('errors/src/ErrorIds');
 const ErrorMessages = require('errors/src/ErrorMessages');
 const APIError = require('errors/src/APIError');
 const assert = require('assert');
-const MultiStream = require('multistream');
 
 const eventsGetUtils = require('./helpers/eventsGetUtils');
 
@@ -71,7 +64,7 @@ module.exports = async function (api)
   const eventTypesUrl = config.get('service:eventTypes');
   const auditSettings = config.get('versioning');
   const updatesSettings = config.get('updates');
-  const openSourceSettings = config.get('openSource')
+  const openSourceSettings = config.get('openSource');
   const usersRepository = await getUsersRepository();
   const mall = await getMall();
   const platform = await getPlatform();
@@ -129,7 +122,7 @@ module.exports = async function (api)
     for (const query: StreamQuery of params.arrayOfStreamQueriesWithStoreId) {
       if (query.storeId === 'local') {
         if (query.and == null) query.and = [];
-        query.and.push({any: params.tags.map(t => TAG_PREFIX + t)})
+        query.and.push({any: params.tags.map(t => TAG_PREFIX + t)});
       }
     }
 
@@ -281,14 +274,14 @@ module.exports = async function (api)
     const isDelete: boolean = (context.oldEvent != null) && (context.newEvent == null);
 
     if (isUpdate) {
-      context.oldAccountStreamIds = _.intersection(allAccountStreamsIds, context.oldEvent.streamIds) // rename to oldEvent/newEvent
-      context.accountStreamIds = _.intersection(allAccountStreamsIds, context.newEvent.streamIds)
+      context.oldAccountStreamIds = _.intersection(allAccountStreamsIds, context.oldEvent.streamIds); // rename to oldEvent/newEvent
+      context.accountStreamIds = _.intersection(allAccountStreamsIds, context.newEvent.streamIds);
       context.doesEventBelongToAccountStream = context.oldAccountStreamIds.length > 0;
     } else if (isDelete) {
-      context.oldAccountStreamIds = _.intersection(allAccountStreamsIds, context.oldEvent.streamIds)
+      context.oldAccountStreamIds = _.intersection(allAccountStreamsIds, context.oldEvent.streamIds);
       context.doesEventBelongToAccountStream = context.oldAccountStreamIds.length > 0;
     } else {
-      context.accountStreamIds = _.intersection(allAccountStreamsIds, context.newEvent.streamIds)
+      context.accountStreamIds = _.intersection(allAccountStreamsIds, context.newEvent.streamIds);
       context.doesEventBelongToAccountStream = context.accountStreamIds.length > 0;
     }
     next();
@@ -451,7 +444,7 @@ module.exports = async function (api)
   }
 
   function backwardCompatibilityOnResult(context: MethodContext, params: mixed, result: Result, next: ApiCallback) {
-    if (result.event != null) _applyBackwardCompatibilityOnEvent(result.event, context)
+    if (result.event != null) _applyBackwardCompatibilityOnEvent(result.event, context);
     next();
   }
 
@@ -730,10 +723,9 @@ module.exports = async function (api)
 
     const filter = function(eventData) {
       return eventData.id != result.event.id;
-    }
+    };
 
-    const updatedEvents = await mall.events.updateMany(context.user.id, query, { filter: filter, removeStreams: [STREAM_ID_ACTIVE]});
-
+    await mall.events.updateMany(context.user.id, query, { filter: filter, removeStreams: [STREAM_ID_ACTIVE]});
 
     next();
   }
@@ -748,7 +740,7 @@ module.exports = async function (api)
       // if event is a deletion 'id' is given by result.eventDeletion
       const updatedEventId: string = isDelete ? _.pick(result.eventDeletion, ['id']) : _.pick(result.event, ['id']);
       const subject: string = isDelete ? pubsub.SERIES_DELETE_EVENTID_USERNAME : pubsub.SERIES_UPDATE_EVENTID_USERNAME;
-      const payload = { username: context.user.username, event: updatedEventId }
+      const payload = { username: context.user.username, event: updatedEventId };
       pubsub.series.emit(subject, payload)
     }
 
@@ -810,14 +802,14 @@ module.exports = async function (api)
       }
       const streamIdsNotFoundList: Array<string> = [];
       const streamIdsTrashed: Array<string> = [];
-      for (streamId of event.streamIds) {
+      for (const streamId of event.streamIds) {
         const stream = await context.streamForStreamId(streamId, 'local');
         if (! stream) {
           streamIdsNotFoundList.push(streamId);
         } else if (stream.trashed) {
           streamIdsTrashed.push(streamId);
         }
-      };
+      }
 
       if (streamIdsNotFoundList.length > 0 ) {
         return next(errors.unknownReferencedResource(
@@ -915,7 +907,7 @@ module.exports = async function (api)
       const stream = await context.streamForStreamId(streamData.id, 'local');
       if (stream == null) {
         await mall.streams.create(context.user.id, streamData);
-        streamIdsCreated.push(streamData.id)
+        streamIdsCreated.push(streamData.id);
       }
     }
 
@@ -1034,7 +1026,7 @@ module.exports = async function (api)
         key: streamIdWithoutPrefix,
         value: content,
         isUnique: true
-      }]
+      }];
 
       await platform.updateUserAndForward(username, operations);
 

--- a/components/api-server/test/acceptance/accesses.test.js
+++ b/components/api-server/test/acceptance/accesses.test.js
@@ -30,7 +30,7 @@ describe('accesses', () => {
   });
 
   describe('access deletions', () => {
-    
+
     let userId, streamId, activeToken, deletedToken, accessToken;
     before(async () => {
       userId = cuid();
@@ -39,21 +39,21 @@ describe('accesses', () => {
       deletedToken = cuid();
       accessToken = cuid();
     });
-  
+
     after(async () => {
       let mongoFixtures = databaseFixture(await produceMongoConnection());
       await mongoFixtures.context.cleanEverything();
     });
     describe('when given a few existing accesses', () => {
-  
+
       const deletedTimestamp = timestamp.now('-1h');
-      
+
       let mongoFixtures;
       before(async () => {
           mongoFixtures = databaseFixture(await produceMongoConnection());
           const user = await mongoFixtures.user(userId);
           await user.stream({ id: streamId }, () => {});
-    
+
           await user.access({
             type: 'app', token: activeToken,
             name: 'active access', permissions: []
@@ -63,12 +63,12 @@ describe('accesses', () => {
             name: 'deleted access', permissions: [],
             deleted: deletedTimestamp
           });
-    
+
           await user.access({ token: accessToken, type: 'personal' });
           await user.session(accessToken);
       });
-  
-  
+
+
       let server;
       before(async () => {
         server = await context.spawn();
@@ -76,10 +76,10 @@ describe('accesses', () => {
       after(() => {
         server.stop();
       });
-  
+
       describe('accesses.get', () => {
         let res, accesses, deletions;
-  
+
         before(async () => {
           res = await server.request()
             .get(`/${userId}/accesses?includeDeletions=true`)
@@ -95,34 +95,34 @@ describe('accesses', () => {
             assert.include(access.apiEndpoint, access.token);
           }
         });
-  
-  
+
+
         it('[P12L] should contain deletions', () => {
           assert.isNotNull(deletions);
         });
-  
+
         it('[BQ7M] contains active accesses', () => {
           assert.equal(accesses.length, 2);
           const activeAccess = accesses.find( a => a.token === activeToken );
           assert.isNotNull(activeAccess);
         });
-  
+
         it('[NVCQ] contains deleted accesses as well', () => {
           assert.equal(deletions.length, 1);
           assert.equal(deletions[0].token, deletedToken);
         });
-  
+
         it('[6ZQL] deleted access are in UTC (seconds) format', () => {
           const deletedAccess = deletions[0];
           assert.equal(deletedAccess.deleted, deletedTimestamp);
         });
       });
-  
+
       describe('accesses.create', () => {
-  
+
         describe('for a valid access', () => {
           let createdAccess;
-  
+
           const access = {
             name: 'whatever',
             type: 'app',
@@ -133,7 +133,7 @@ describe('accesses', () => {
               }
             ]
           };
-  
+
           before(async () => {
             const res = await server.request()
               .post(`/${userId}/accesses`)
@@ -141,7 +141,7 @@ describe('accesses', () => {
               .send(access);
             createdAccess = res.body.access;
           });
-  
+
           it('[N3Q1] should contain an access', () => {
             assert.isNotNull(createdAccess);
           });
@@ -149,16 +149,16 @@ describe('accesses', () => {
           it('[8UOW] access should contain token and apiEndpoint', () => {
             assert.exists(createdAccess.token);
             assert.exists(createdAccess.apiEndpoint, 'Missing API endpoint');
-            assert.include(createdAccess.apiEndpoint, createdAccess.token);           
+            assert.include(createdAccess.apiEndpoint, createdAccess.token);
           });
-  
+
           it('[J77Z] should contain the set values, but no "deleted" field in the API response', () => {
             assert.deepEqual(access, _.pick(createdAccess,
               ['name', 'permissions', 'type']
             ));
             assert.notExists(createdAccess.deleted);
           });
-  
+
           it('[A4JP] should contain the field "deleted:null" in the database', (done) => {
             storage.findAll({ id: userId }, {}, (err, accesses) => {
               const deletedAccess = accesses.find(a => a.name === access.name);
@@ -167,10 +167,10 @@ describe('accesses', () => {
             });
           });
         });
-  
+
         describe('for a deleted access', () => {
           let res, error;
-  
+
           const deletedAccess = {
             name: 'whatever',
             type: 'app',
@@ -180,30 +180,30 @@ describe('accesses', () => {
             }],
             deleted: Date.now() / 1000
           };
-  
+
           before(async () => {
             res = await server.request()
               .post(`/${userId}/accesses`)
               .set('Authorization', accessToken)
               .send(deletedAccess);
           });
-  
+
           it('[1DJ6] should return an error', () => {
             error = res.body.error;
             assert.isNotNull(error);
           });
-  
+
           it('[7ZPK] error should say that the deleted field is forbidden upon creation', () => {
             assert.equal(error.id, ErrorIds.InvalidParametersFormat);
           });
-  
+
         });
-        
+
       });
-  
+
       describe('accesses.update', () => {
         let res, error, activeAccess;
-  
+
         before(async () => {
           res = await server.request()
             .get(`/${userId}/accesses`)
@@ -215,38 +215,38 @@ describe('accesses', () => {
             .send({
               update: { deleted: Date.now() / 1000 }
             });
-          error = res.body.error; 
+          error = res.body.error;
         });
-  
+
         it('[JNJK] should return an error', () => {
           assert.isNotNull(error);
         });
-  
+
         it('[OS36] error should say that the deleted field is forbidden upon update', () => {
           assert.equal(error.id, ErrorIds.Gone);
         });
-  
+
       });
-  
+
     });
   });
-  
+
   describe('Delete app access', () => {
-  
-    let username, streamId, access, 
+
+    let username, streamId, access,
         sharedAccess1, sharedAccess2, sharedAccess3,
         expiredSharedAccess;
     before(() => {
       username = cuid();
       streamId = charlatan.Lorem.word();
     });
-  
+
     let mongoFixtures;
     before(async () => {
       mongoFixtures = databaseFixture(await produceMongoConnection());
       const user = await mongoFixtures.user(username);
       await user.stream({ id: streamId }, () => {});
-  
+
       access = await user.access({
         type: 'app',
         name: charlatan.Lorem.word() + 0,
@@ -257,7 +257,7 @@ describe('accesses', () => {
       });
       access = access.attrs;
       sharedAccess1 = await user.access({
-        type: 'shared', 
+        type: 'shared',
         name: charlatan.Lorem.word() + 1,
         permissions: [{
           streamId: streamId,
@@ -265,9 +265,9 @@ describe('accesses', () => {
         }],
         createdBy: access.id,
       });
-      sharedAccess1 = sharedAccess1.attrs;   
+      sharedAccess1 = sharedAccess1.attrs;
       sharedAccess2 = await user.access({
-        type: 'shared', 
+        type: 'shared',
         name: charlatan.Lorem.word() + 2,
         permissions: [{
           streamId: streamId,
@@ -275,10 +275,10 @@ describe('accesses', () => {
         }],
         createdBy: access.id,
       });
-      sharedAccess2 = sharedAccess2.attrs;    
+      sharedAccess2 = sharedAccess2.attrs;
       // some unrelated access that shouldn't be changed
       sharedAccess3 = await user.access({
-        type: 'shared', 
+        type: 'shared',
         name: charlatan.Lorem.word() + 3,
         permissions: [{
           streamId: streamId,
@@ -300,7 +300,7 @@ describe('accesses', () => {
     after(async () => {
       await mongoFixtures.clean();
     });
-  
+
     let server;
     before(async () => {
       server = await context.spawn();
@@ -308,7 +308,7 @@ describe('accesses', () => {
     after(() => {
       server.stop();
     });
-  
+
     describe('when deleting an app access that created shared accesses', () => {
       let res;
       before(async () => {
@@ -316,7 +316,7 @@ describe('accesses', () => {
           .del(`/${username}/accesses/${access.id}`)
           .set('Authorization', access.token)
       });
-  
+
       it('[WE2O] should return the accessDeletion and relatedDeletions', () => {
         const accessDeletion = res.body.accessDeletion;
         const relatedDeletions = res.body.relatedDeletions;
@@ -354,9 +354,9 @@ describe('accesses', () => {
         });
       });
     });
-  
+
   });
-  
+
   describe('access expiry', () => {
     // Uses dynamic fixtures:
     let mongoFixtures;
@@ -365,35 +365,35 @@ describe('accesses', () => {
     let userId, streamId, accessToken, expiredToken, validId;
     let hasExpiryId, hasExpiryToken;
     before(async () => {
-      userId = cuid(); 
+      userId = cuid();
       streamId = cuid();
-      accessToken = cuid(); 
-      expiredToken = cuid(); 
-      validId = cuid(); 
-      hasExpiryId = cuid(); 
-      hasExpiryToken = cuid(); 
+      accessToken = cuid();
+      expiredToken = cuid();
+      validId = cuid();
+      hasExpiryId = cuid();
+      hasExpiryToken = cuid();
     });
-  
+
     describe('when given a few existing accesses', () => {
-      
+
       let mongoFixtures;
       before(async () => {
         mongoFixtures = databaseFixture(await produceMongoConnection());
         const user = await mongoFixtures.user(userId);
         await user.stream({id: streamId}, () => { });
-        
+
         // A token that expired one day ago
         await user.access({
-          type: 'app', token: expiredToken, 
+          type: 'app', token: expiredToken,
           expires: timestamp.now('-1d'),
           name: 'expired access',
-          permissions: [], 
+          permissions: [],
         });
-        
+
         // A token that is still valid
         await user.access({
-          id: hasExpiryId, 
-          type: 'app', token: hasExpiryToken, 
+          id: hasExpiryId,
+          type: 'app', token: hasExpiryToken,
           expires: timestamp.now('1d'),
           name: 'valid access',
           permissions: [
@@ -404,64 +404,64 @@ describe('accesses', () => {
             }
           ]
         });
-          
+
         // A token that did never expire
         await user.access({
           id: validId,
-          type: 'app', token: cuid(), 
+          type: 'app', token: cuid(),
           name: 'doesnt expire',
         });
-  
+
         await user.access({token: accessToken, type: 'personal'});
         await user.session(accessToken);
       });
-  
+
       let server;
       before(async () => {
         server = await context.spawn();
       });
       after(() => {
-        server.stop(); 
+        server.stop();
       });
-  
+
       const isExpired = e => e.expires != null && timestamp.now() > e.expires;
-  
+
       describe('accesses.get', () => {
         describe('vanilla version', () => {
-          let res; 
-          let accesses; 
-          
+          let res;
+          let accesses;
+
           beforeEach(async () => {
             res = await server.request()
               .get(`/${userId}/accesses`)
               .set('Authorization', accessToken);
-              
+
             accesses = res.body.accesses;
           });
-  
+
           it('[489J] succeeds', () => {
             assert.isNotNull(accesses);
           });
           it('[7NPE] contains only active accesses', () => {
-            for (const a of accesses) 
-              assert.isFalse(isExpired(a), 
+            for (const a of accesses)
+              assert.isFalse(isExpired(a),
                 `Access '${a.name}' is expired`);
           });
         });
-  
+
         describe('when given the includeExpired=true parameter', () => {
-          let res; 
-          let accesses; 
-          
+          let res;
+          let accesses;
+
           beforeEach(async () => {
             res = await server.request()
               .get(`/${userId}/accesses`)
               .set('Authorization', accessToken)
               .query('includeExpired=true');
-              
+
             accesses = res.body.accesses;
           });
-          
+
           it('[PIGE] succeeds', () => {
             assert.isNotNull(accesses);
           });
@@ -483,22 +483,22 @@ describe('accesses', () => {
               },
             ],
           };
-          
+
           let res, access;
           beforeEach(async () => {
             res = await server.request()
               .post(`/${userId}/accesses`)
               .set('Authorization', accessToken)
               .send(attrs);
-            
+
             access = res.body.access;
-            
+
             if (! res.ok && res.body.error != null) {
               console.error(res.body.error);  // eslint-disable-line no-console
               // console.dir(res.body.error.data[0].inner);
             }
           });
-          
+
           it('[3ONA] creates an access with set expiry timestamp', () => {
             assert.strictEqual(res.status, 201);
             assert.isAbove(access.expires, timestamp.now());
@@ -516,22 +516,22 @@ describe('accesses', () => {
               },
             ],
           };
-          
+
           let res, access;
           beforeEach(async () => {
             res = await server.request()
               .post(`/${userId}/accesses`)
               .set('Authorization', accessToken)
               .send(attrs);
-            
+
             access = res.body.access;
-            
+
             if (! res.ok && res.body.error != null) {
               console.error(res.body.error);  // eslint-disable-line no-console
               // console.dir(res.body.error.data[0].inner);
             }
           });
-          
+
           it('[8B65] creates an expired access', () => {
             assert.strictEqual(res.status, 201);
             assert.isAbove(timestamp.now(), access.expires);
@@ -549,7 +549,7 @@ describe('accesses', () => {
               },
             ],
           };
-          
+
           let res;
           beforeEach(async () => {
             res = await server.request()
@@ -557,83 +557,83 @@ describe('accesses', () => {
               .set('Authorization', accessToken)
               .send(attrs);
           });
-                  
+
           it('[JHWH] fails', () => {
             assert.strictEqual(res.status, 400);
             assert.strictEqual(res.body.error.message, 'expireAfter cannot be negative.');
           });
         });
       });
-  
+
       describe('accesses.checkApp', () => {
         describe('when the matching access is not expired', () => {
-          let res; 
+          let res;
           beforeEach(async () => {
             res = await server.request()
               .post(`/${userId}/accesses/check-app`)
               .set('Authorization', accessToken)
-              .send({ 
-                requestingAppId: 'valid access', 
+              .send({
+                requestingAppId: 'valid access',
                 requestedPermissions: [
                   {
                     'streamId': 'diary',
                     'defaultName': 'Diary',
                     'level': 'read'
                   }
-                ] 
+                ]
               });
           });
-          
+
           it('[B66B] returns the matching access', () => {
             assert.isTrue(res.ok);
             assert.strictEqual(res.body.matchingAccess.token, hasExpiryToken);
           });
         });
         describe('when the matching access is expired', () => {
-          let res; 
+          let res;
           beforeEach(async () => {
             res = await server.request()
               .post(`/${userId}/accesses/check-app`)
               .set('Authorization', accessToken)
-              .send({ 
-                requestingAppId: 'expired access', 
-                requestedPermissions: [] 
+              .send({
+                requestingAppId: 'expired access',
+                requestedPermissions: []
               });
-              
+
             // NOTE It is important that the reason why we have a mismatch here is
-            // that the access is expired, not that we're asking for different 
-            // permissions. 
+            // that the access is expired, not that we're asking for different
+            // permissions.
           });
-          
+
           it('[DLHJ] returns no match', () => {
             assert.isUndefined(res.body.matchingAccess);
-            
+
             const mismatching = res.body.mismatchingAccess;
             assert.strictEqual(mismatching.token, expiredToken);
           });
         });
       });
-      
+
       describe('other API accesses', () => {
-        
+
         function apiAccess(token) {
           return server.request()
             .get(`/${userId}/events`)
             .set('Authorization', token);
         }
-        
+
         describe('using an expired access', () => {
           let res;
           beforeEach(async () => {
             res = await apiAccess(expiredToken);
           });
-          
+
           it('[AJG5] fails', () => {
             assert.strictEqual(res.status, 403);
           });
           it('[KGT4] returns a proper error message', () => {
-            const error = res.body.error; 
-            
+            const error = res.body.error;
+
             assert.isNotNull(error);
             assert.strictEqual(error.id, 'forbidden');
             assert.strictEqual(error.message, 'Access has expired.');
@@ -644,7 +644,7 @@ describe('accesses', () => {
           beforeEach(async () => {
             res = await apiAccess(accessToken);
           });
-            
+
           it('[CBRF] succeeds', () => {
             assert.strictEqual(res.status, 200);
           });
@@ -652,7 +652,7 @@ describe('accesses', () => {
       });
     });
   });
-  
+
   describe('access client data', () => {
     let mongoFixtures;
     function sampleAccess(name, clientData) {
@@ -664,14 +664,14 @@ describe('accesses', () => {
         clientData: clientData,
       };
     }
-    
+
     // Set up a few ids that we'll use for testing. NOTE that these ids will
     // change on every test run.
     let userId, streamId, accessToken, complexClientData, existingAccess;
     let toBeUpdateAccess1, toBeUpdateAccess2, toBeUpdateAccess3, emptyClientDataAccess;
     let fixtureAccesses;
     before(async () => {
-      userId = cuid(); 
+      userId = cuid();
       streamId = cuid();
       accessToken = cuid();
       complexClientData = {
@@ -687,9 +687,9 @@ describe('accesses', () => {
       emptyClientDataAccess = sampleAccess('Access with empty clientData', null);
       fixtureAccesses = [existingAccess, toBeUpdateAccess1, toBeUpdateAccess2, toBeUpdateAccess3, emptyClientDataAccess];
     });
-  
+
     describe('when given a few existing accesses', () => {
-  
+
       let mongoFixtures;
       before(async () => {
         mongoFixtures = databaseFixture(await produceMongoConnection());
@@ -703,29 +703,29 @@ describe('accesses', () => {
         await user.access(emptyClientDataAccess);
         await user.session(accessToken);
       });
-  
+
       let server;
       before(async () => {
         server = await context.spawn();
       });
       after(() => {
-        server.stop(); 
+        server.stop();
       });
-  
+
       describe('accesses.get', () => {
-        let res, accesses; 
+        let res, accesses;
         before(async () => {
           res = await server.request()
             .get(`/${userId}/accesses`)
             .set('Authorization', accessToken);
-            
+
           accesses = res.body.accesses;
         });
-  
+
         it('[KML2] succeeds', () => {
           assert.exists(accesses);
         });
-  
+
         it('[NY85] contains existing accesses with clientData', () => {
           for (const a of accesses) {
             const fixtureAccess =
@@ -735,9 +735,9 @@ describe('accesses', () => {
           }
         });
       });
-  
+
       describe('accesses.create', () => {
-  
+
         function sampleAccess (name, clientData) {
           return {
             name: name,
@@ -751,7 +751,7 @@ describe('accesses', () => {
             clientData: clientData,
           };
         }
-  
+
         function checkResultingAccess (res) {
           const access = res.body.access;
           assert.isTrue(res.ok);
@@ -759,7 +759,7 @@ describe('accesses', () => {
           assert.exists(access);
           return access;
         }
-  
+
         describe('when called with clientData={}', () => {
           let res, access;
           before(async () => {
@@ -767,16 +767,16 @@ describe('accesses', () => {
               .post(`/${userId}/accesses`)
               .set('Authorization', accessToken)
               .send(sampleAccess('With empty clientData', {}));
-            
+
             access = checkResultingAccess(res);
           });
-          
+
           it('[OMUO] creates an access with empty clientData', () => {
             assert.strictEqual(res.status, 201);
             assert.deepEqual(access.clientData, {});
           });
         });
-  
+
         describe('when called with clientData=null', () => {
           let res;
           before(async () => {
@@ -785,13 +785,13 @@ describe('accesses', () => {
               .set('Authorization', accessToken)
               .send(sampleAccess('With null clientData', null));
           });
-          
+
           it('[E5C1] throws a schema error', () => {
             assert.isFalse(res.ok);
             assert.exists(res.body.error);
           });
         });
-  
+
         describe('when called with complex clientData', () => {
           let res, access;
           before(async () => {
@@ -799,49 +799,49 @@ describe('accesses', () => {
               .post(`/${userId}/accesses`)
               .set('Authorization', accessToken)
               .send(sampleAccess('With complex clientData', complexClientData));
-  
+
             access = checkResultingAccess(res);
           });
-                  
+
           it('[JYD4] creates an access with complex clientData', () => {
             assert.strictEqual(res.status, 201);
             assert.deepEqual(access.clientData, complexClientData);
           });
         });
       });
-  
+
       describe('accesses.checkApp', () => {
-  
+
         async function checkAppRequest(req) {
           const res = await server.request()
             .post(`/${userId}/accesses/check-app`)
             .set('Authorization', accessToken)
             .send(req);
-  
+
           assert.isTrue(res.ok);
           assert.exists(res.body);
           assert.notExists(res.body.error);
           return res.body;
         }
-  
+
         describe('when the provided clientData matches the existing clientData', () => {
           let body;
           before(async () => {
-            body = await checkAppRequest({ 
+            body = await checkAppRequest({
               requestingAppId: existingAccess.name,
               requestedPermissions: existingAccess.permissions,
               clientData: existingAccess.clientData,
             });
           });
-          
+
           it('[U1AM] returns the matching access', () => {
             assert.exists(body.matchingAccess);
             assert.strictEqual(body.matchingAccess.id, existingAccess.id);
           });
         });
-        
+
         describe('when the provided clientData does not match the existing clientData', () => {
-          let body; 
+          let body;
           before(async () => {
             body = await checkAppRequest({
               requestingAppId: existingAccess.name,
@@ -849,22 +849,22 @@ describe('accesses', () => {
               clientData: {},
             });
           });
-          
+
           it('[2EER] returns no match', () => {
             assert.exists(body.mismatchingAccess);
             assert.strictEqual(body.mismatchingAccess.id, existingAccess.id);
           });
         });
-  
+
         describe('when no clientData is provided but existing access has one', () => {
-          let body; 
+          let body;
           before(async () => {
             body = await checkAppRequest({
               requestingAppId: existingAccess.name,
               requestedPermissions: existingAccess.permissions,
             });
           });
-          
+
           it('[DHZQ] returns no match', () => {
             assert.exists(body.mismatchingAccess);
             assert.strictEqual(body.mismatchingAccess.id, existingAccess.id);
@@ -873,17 +873,17 @@ describe('accesses', () => {
       });
     });
   });
-  
+
   describe('access-info', () => {
-    
+
     let mongoFixtures, userId,
         token;
-  
+
     before(() => {
       token = cuid();
       userId = cuid();
     })
-  
+
     before(async () => {
       mongoFixtures = databaseFixture(await produceMongoConnection());
       const user = await mongoFixtures.user(userId);
@@ -895,19 +895,19 @@ describe('accesses', () => {
         }],
       });
     });
-  
+
     let server;
     before(async () => {
       server = await context.spawn();
     });
     after(() => {
-      server.stop(); 
+      server.stop();
     });
-  
+
     function path() {
       return `/${userId}/access-info`;
     }
-  
+
     it('[PH0K] should return the username', async () => {
       const res = await server.request()
         .get(path())
@@ -917,7 +917,6 @@ describe('accesses', () => {
       assert.exists(body.user.username)
       assert.equal(body.user.username, userId);
     });
-  
+
   });
 });
-

--- a/components/api-server/test/acceptance/events-audit.test.js
+++ b/components/api-server/test/acceptance/events-audit.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/*global describe, before, it*/
+/* global describe, before, it */
 
 const { getConfig } = require('@pryv/boiler');
 const { databaseFixture } = require('test-helpers');
@@ -66,7 +66,7 @@ describe('Audit logs events', () => {
     });
     await user.session(personalToken);
 
-    server = await context.spawn({ 
+    server = await context.spawn({
       dnsLess: { isActive: true }, // so updating account streams does not notify register
       audit: {
         active: true,

--- a/components/api-server/test/acceptance/events.default-streams.test.js
+++ b/components/api-server/test/acceptance/events.default-streams.test.js
@@ -5,8 +5,6 @@
  * Proprietary and confidential
  */
 const cuid = require('cuid');
-const _ = require('lodash');
-const bluebird = require('bluebird');
 const nock = require('nock');
 const path = require('path');
 const assert = require('chai').assert;
@@ -64,7 +62,7 @@ describe("[FG5R] Events of system streams", () => {
 
   /**
    * Create additional event
-   * @param string streamId 
+   * @param string streamId
    */
   async function createAdditionalEvent (streamId) {
     eventDataForadditionalEvent = {
@@ -102,7 +100,7 @@ describe("[FG5R] Events of system streams", () => {
     const helpers = require('api-server/test/helpers');
     validation = helpers.validation;
     mongoFixtures = databaseFixture(await produceMongoConnection());
-  
+
     app = getApplication(true);
     await app.initiate();
 
@@ -113,7 +111,7 @@ describe("[FG5R] Events of system streams", () => {
       emit: (...args) => axonMsgs.push(args),
     };
     pubsub.setTestNotifier(axonSocket);
-    
+
     pubsub.status.emit(pubsub.SERVER_READY);
     await require("api-server/src/methods/events")(app.api);
 
@@ -162,7 +160,7 @@ describe("[FG5R] Events of system streams", () => {
         // lets separate core events from all other events and validate them separatelly
         separatedEvents = validation.separateAccountStreamsAndOtherEvents(res.body.events);
       });
-      
+
       it('[DRFH] should return visible system events only', () => {
         const accountStreams = Object.keys(SystemStreamsSerializer.getReadableAccountMapForTests());
         assert.equal(separatedEvents.accountStreamsEvents.length, accountStreams.length);
@@ -175,7 +173,7 @@ describe("[FG5R] Events of system streams", () => {
         });
       });
     });
-    
+
     describe('When using a shared access with a read-level permission on all streams (star) and a visible system stream', () => {
       let sharedAccess;
       let systemStreamId;
@@ -194,7 +192,7 @@ describe("[FG5R] Events of system streams", () => {
             level: 'read'
           }]
         });
-        
+
       });
 
       it('[GF3A] should return only the account event for which a permission was explicitely provided', async () => {
@@ -258,13 +256,13 @@ describe("[FG5R] Events of system streams", () => {
         it('[Y2OA] should return 403', () => {
           assert.equal(res.status, 403);
         });
-  
+
         it('[DHZE] should return the right error message', () => {
           assert.equal(res.body.error.id, ErrorIds.Forbidden);
         });
       });
     });
-    
+
     describe('When using a shared access with a read-level permission on all streams (star) and a visible system stream', () => {
       let defaultEvent;
       let systemStreamId ;
@@ -283,7 +281,7 @@ describe("[FG5R] Events of system streams", () => {
             level: 'read'
           }]
         });
-        
+
         defaultEvent = await findDefaultCoreEvent(systemStreamId);
         res = await request.get(path.join(basePath, defaultEvent.id))
           .set('authorization', sharedAccess.attrs.token);
@@ -301,7 +299,7 @@ describe("[FG5R] Events of system streams", () => {
   describe('POST /events', () => {
     let eventData;
     describe('When using a personal access', () => {
-      
+
       describe('to create an editable system event', () => {
         describe('which is non indexed and non unique', () => {
           before(async function () {
@@ -311,7 +309,7 @@ describe("[FG5R] Events of system streams", () => {
               content: charlatan.Lorem.characters(7),
               type: 'string/pryv'
             };
-  
+
             res = await request.post(basePath)
               .send(eventData)
               .set('authorization', access.token);
@@ -327,7 +325,7 @@ describe("[FG5R] Events of system streams", () => {
           it('[A9DC] should add the ‘active’ streamId to the new event which should be removed from other events of the same stream', async () => {
             assert.equal(res.body.event.streamIds.includes(SystemStreamsSerializer.options.STREAM_ID_ACTIVE), true);
 
-            const allEvents = await mall.events.get(user.attrs.id, 
+            const allEvents = await mall.events.get(user.attrs.id,
               {streams: [{any: [SystemStreamsSerializer.addCustomerPrefixToStreamId('phoneNumber')]}]});
 
             assert.equal(allEvents.length, 2);
@@ -339,17 +337,17 @@ describe("[FG5R] Events of system streams", () => {
           });
         });
         describe('which is indexed', function () {
-          
+
           describe('when the new value is valid', () => {
             before(async function () {
-            
+
               await createUser();
               eventData = {
                 streamIds: [SystemStreamsSerializer.addPrivatePrefixToStreamId('language')],
                 content: charlatan.Lorem.characters(7),
                 type: 'string/pryv'
               };
-  
+
               nock.cleanAll();
               scope = nock(config.get('services:register:url'))
               scope.put('/users',
@@ -357,12 +355,12 @@ describe("[FG5R] Events of system streams", () => {
                   serviceRegisterRequest = body;
                   return true;
                 }).reply(200, { errors: [] });
-  
+
               res = await request.post(basePath)
                 .send(eventData)
                 .set('authorization', access.token);
             });
-  
+
             it('[8C80] should return 201', () => {
               assert.equal(res.status, 201);
             });
@@ -372,7 +370,7 @@ describe("[FG5R] Events of system streams", () => {
               assert.deepEqual(res.body.event.streamIds, [SystemStreamsSerializer.addPrivatePrefixToStreamId('language'), SystemStreamsSerializer.options.STREAM_ID_ACTIVE]);
             });
             it('[467D] should add the ‘active’ streamId to the new event which should be removed from other events of the same stream', async () => {
-              const allEvents = await mall.events.get(user.attrs.id, 
+              const allEvents = await mall.events.get(user.attrs.id,
                 {streams: [{any: [SystemStreamsSerializer.addPrivatePrefixToStreamId('language')]}]});
 
               assert.equal(allEvents[0].streamIds.includes(SystemStreamsSerializer.options.STREAM_ID_ACTIVE), true);
@@ -383,7 +381,7 @@ describe("[FG5R] Events of system streams", () => {
             it('[199D] should notify register with the new data', function () {
               if (isDnsLess) this.skip();
               assert.equal(scope.isDone(), true);
-  
+
               assert.deepEqual(serviceRegisterRequest, {
                 username: user.attrs.username,
                 user: {
@@ -399,24 +397,24 @@ describe("[FG5R] Events of system streams", () => {
             });
           });
 
-          
+
 
           describe('when the new value is invalid', () => {
 
             before(async function () {
-            
+
               await createUser();
               eventData = {
                 streamIds: [SystemStreamsSerializer.addPrivatePrefixToStreamId('language')],
                 content: [charlatan.Lorem.characters(7)],
                 type: 'string/pryv'
               };
-  
+
               res = await request.post(basePath)
                 .send(eventData)
                 .set('authorization', access.token);
             });
-  
+
             it('[PQHR] should return 400', () => {
               assert.equal(res.status, 400);
             });
@@ -436,7 +434,7 @@ describe("[FG5R] Events of system streams", () => {
                 content: charlatan.Lorem.characters(7),
                 type: 'string/pryv'
               };
-  
+
               nock.cleanAll();
               scope = nock(config.get('services:register:url'))
               scope.put('/users',
@@ -444,7 +442,7 @@ describe("[FG5R] Events of system streams", () => {
                 serviceRegisterRequest = body;
                 return true;
               }).reply(200, { errors: [] });
-  
+
               res = await request.post(basePath)
                 .send(eventData)
                 .set('authorization', access.token);
@@ -457,7 +455,7 @@ describe("[FG5R] Events of system streams", () => {
             });
             it('[YS79] should return the created event', () => {
               assert.equal(res.body.event.content, eventData.content);
-              assert.equal(res.body.event.type, eventData.type);    
+              assert.equal(res.body.event.type, eventData.type);
             });
             it('[DA23] should add the ‘active’ streamId to the new event which should be removed from other events of the same stream', async () => {
               assert.deepEqual(res.body.event.streamIds, [streamId, SystemStreamsSerializer.options.STREAM_ID_ACTIVE, SystemStreamsSerializer.options.STREAM_ID_UNIQUE]);
@@ -469,7 +467,7 @@ describe("[FG5R] Events of system streams", () => {
             it('[D316] should notify register with the new data', function () {
               if (isDnsLess) this.skip();
               assert.equal(scope.isDone(), true);
-              
+
               assert.deepEqual(serviceRegisterRequest, {
                 username: user.attrs.username,
                 user: {
@@ -493,7 +491,7 @@ describe("[FG5R] Events of system streams", () => {
                 content: charlatan.Lorem.characters(7),
                 type: 'string/pryv'
               };
-  
+
               nock.cleanAll();
               nock(config.get('services:register:url')).put('/users')
                 .reply(409, {
@@ -504,12 +502,12 @@ describe("[FG5R] Events of system streams", () => {
                     }
                   }
                 });
-  
+
               res = await request.post(basePath)
                 .send(eventData)
                 .set('authorization', access.token);
             });
-            
+
             it('[89BC] should return 409', () => {
               assert.equal(res.status, 409);
             });
@@ -531,14 +529,14 @@ describe("[FG5R] Events of system streams", () => {
                 content: email,
                 type: 'string/pryv'
               };
-  
+
               nock.cleanAll();
               nock(config.get('services:register:url')).put('/users',
                 (body) => {
                   serviceRegisterRequest = body;
                   return true;
                 }).times(2).reply(200, { errors: [] });
-  
+
                 await request.post(basePath)
                   .send(eventData)
                   .set('authorization', access.token);
@@ -546,7 +544,7 @@ describe("[FG5R] Events of system streams", () => {
                   .send(eventData)
                   .set('authorization', access.token);
             });
-  
+
             it('[2021] should return a 409 error', () => {
               assert.equal(res.status, 409);
             });
@@ -555,7 +553,7 @@ describe("[FG5R] Events of system streams", () => {
               assert.deepEqual(res.body.error.data, { email: email });
             });
           });
-          
+
         });
       });
 
@@ -567,7 +565,7 @@ describe("[FG5R] Events of system streams", () => {
             content: charlatan.Lorem.characters(7),
             type: 'password-hash/string'
           };
-  
+
           res = await request.post(basePath)
             .send(eventData)
             .set('authorization', access.token);
@@ -608,7 +606,7 @@ describe("[FG5R] Events of system streams", () => {
             serviceRegisterRequest = body;
             return true;
           }).reply(200, { errors: [] });
-        
+
         eventData = {
           streamIds: [systemStreamId],
           content: charlatan.Lorem.characters(7),
@@ -683,7 +681,7 @@ describe("[FG5R] Events of system streams", () => {
   describe('PUT /events/<id>', () => {
 
     describe('when using a personal access', () => {
-      
+
       describe('to update an editable system event', () => {
         let scope;
         let serviceRegisterRequest;
@@ -694,13 +692,13 @@ describe("[FG5R] Events of system streams", () => {
             type: 'string/pryv'
           };
           const initialEvent = await getOneEvent(user.attrs.id, streamId);
-  
+
           res = await request.put(path.join(basePath, initialEvent.id))
             .send(eventData)
             .set('authorization', access.token);
           return res;
         }
-  
+
         describe('which is non indexed and non unique', () => {
           before(async function () {
             await createUser();
@@ -709,7 +707,7 @@ describe("[FG5R] Events of system streams", () => {
               type: 'string/pryv'
             };
             const initialEvent = await getOneEvent(user.attrs.id, SystemStreamsSerializer.addCustomerPrefixToStreamId('phoneNumber'));
-          
+
             res = await request.put(path.join(basePath, initialEvent.id))
               .send(eventData)
               .set('authorization', access.token);
@@ -788,7 +786,7 @@ describe("[FG5R] Events of system streams", () => {
                   type: 'string/pryv'
                 };
                 const initialEvent = await  await getOneEvent(user.attrs.id, SystemStreamsSerializer.addCustomerPrefixToStreamId('phoneNumber'));
-  
+
                 res = await request.put(path.join(basePath, initialEvent.id))
                   .send(eventData)
                   .set('authorization', access.token);
@@ -829,7 +827,7 @@ describe("[FG5R] Events of system streams", () => {
                 });
                 it('[E43M] should notify register with the updated data', () => {
                   assert.equal(scope.isDone(), true);
-                  
+
                   assert.deepEqual(serviceRegisterRequest, {
                     username: user.attrs.username,
                     user: {
@@ -972,7 +970,7 @@ describe("[FG5R] Events of system streams", () => {
                   }).times(2).reply(200, { errors: [] });
                 res = await createAdditionalEventAndupdateMainOne(streamId);
               });
-    
+
               it('[HJWE] should return 200', () => {
                 assert.equal(res.status, 200);
               });
@@ -1001,7 +999,7 @@ describe("[FG5R] Events of system streams", () => {
                   if (isDnsLess) this.skip();
                 const streamId = 'email';
                 systemStreamId = SystemStreamsSerializer.addCustomerPrefixToStreamId(streamId);
-    
+
                 await createUser();
                 eventData = {
                   streamIds: [systemStreamId],
@@ -1023,7 +1021,7 @@ describe("[FG5R] Events of system streams", () => {
                     }
                   });
                 const initialEvent =  await getOneEvent(user.attrs.id, systemStreamId);
-    
+
                 res = await request.put(path.join(basePath, initialEvent.id))
                   .send(eventData)
                   .set('authorization', access.token);
@@ -1036,7 +1034,7 @@ describe("[FG5R] Events of system streams", () => {
               it('[5A04] should notify register with the updated data', function () {
                 if (isDnsLess) this.skip();
                 assert.equal(scope.isDone(), true);
-    
+
                 assert.deepEqual(serviceRegisterRequest, {
                   username: user.attrs.username,
                   user: {
@@ -1050,7 +1048,7 @@ describe("[FG5R] Events of system streams", () => {
                   fieldsToDelete: {}
                 });
               });
-              
+
             });
             describe('with a field that is not unique in mongodb', () => {
               before(async function () {
@@ -1070,7 +1068,7 @@ describe("[FG5R] Events of system streams", () => {
                     return true;
                   }).reply(200, { errors: [] });
                 const initialEvent =  await getOneEvent(user2.attrs.id, streamId);
-    
+
                 res = await request.put(path.join(basePath, initialEvent.id))
                   .send(eventData)
                   .set('authorization', access.token);
@@ -1086,7 +1084,7 @@ describe("[FG5R] Events of system streams", () => {
             });
           });
         });
-  
+
       });
 
       describe('to update a non editable system event', () => {
@@ -1097,7 +1095,7 @@ describe("[FG5R] Events of system streams", () => {
             type: 'password-hash/pryv'
           };
           const initialEvent = await getOneEvent(user.attrs.id, SystemStreamsSerializer.options.STREAM_ID_PASSWORDHASH);
-  
+
           res = await request.put(path.join(basePath, initialEvent.id))
             .send(eventData)
             .set('authorization', access.token);
@@ -1128,7 +1126,7 @@ describe("[FG5R] Events of system streams", () => {
             content: charlatan.Internet.email(),
           };
           const initialEvent = await getOneEvent(user.attrs.id, SystemStreamsSerializer.addCustomerPrefixToStreamId('phoneNumber'));
-         
+
           res = await request.put(path.join(basePath, initialEvent.id))
             .send(eventData)
             .set('authorization', access.token);
@@ -1161,7 +1159,7 @@ describe("[FG5R] Events of system streams", () => {
             type: 'string/pryv'
           };
           const initialEvent = await getOneEvent(user.attrs.id, SystemStreamsSerializer.addCustomerPrefixToStreamId('phoneNumber'));
-         
+
           res = await request.put(path.join(basePath, initialEvent.id))
             .send(eventData)
             .set('authorization', sharedAccess.attrs.token);
@@ -1180,7 +1178,7 @@ describe("[FG5R] Events of system streams", () => {
     describe('When using a personal access', () => {
       describe('to delete an editable streams event', () => {
         describe('that has no ‘active’ streamId', () => {
-          describe('which is unique', () => { 
+          describe('which is unique', () => {
             let streamId = 'email';
             let systemStreamId;
             let initialEvent;
@@ -1196,11 +1194,11 @@ describe("[FG5R] Events of system streams", () => {
               await createUser();
               initialEvent = await getOneEvent(user.attrs.id, systemStreamId);
               await createAdditionalEvent(systemStreamId);
-  
+
               res = await request.delete(path.join(basePath, initialEvent.id))
                 .set('authorization', access.token);
             });
-            it('[43B1] should return 200', () => { 
+            it('[43B1] should return 200', () => {
               assert.equal(res.status, 200);
             });
             it('[3E12] should return the trashed event', () => {
@@ -1208,7 +1206,7 @@ describe("[FG5R] Events of system streams", () => {
               assert.equal(res.body.event.trashed, true);
             });
             it('[F328] should notify register with the deleted data', function () {
-              if (isDnsLess) this.skip(); 
+              if (isDnsLess) this.skip();
               assert.equal(scope.isDone(), true);
               assert.deepEqual(serviceRegisterRequest, {
                 username: user.attrs.username,
@@ -1217,7 +1215,7 @@ describe("[FG5R] Events of system streams", () => {
               });
             });
           });
-          describe('which is indexed', () => { 
+          describe('which is indexed', () => {
             let streamId;
             let initialEvent;
             before(async function () {
@@ -1231,16 +1229,16 @@ describe("[FG5R] Events of system streams", () => {
                 }).times(1).reply(200, { errors: [] });
               await createUser();
               initialEvent = await getOneEvent(user.attrs.id, streamId);
-  
+
               await createAdditionalEvent(streamId);
-  
+
               res = await request.delete(path.join(basePath, initialEvent.id))
                 .set('authorization', access.token);
             });
-            it('[1B70] should return 200', () => { 
+            it('[1B70] should return 200', () => {
               assert.equal(res.status, 200);
             });
-            it('[CBB9] should return the trashed event', () => { 
+            it('[CBB9] should return the trashed event', () => {
               assert.equal(res.body.event.id, initialEvent.id);
               assert.equal(res.body.event.trashed, true);
             });
@@ -1256,10 +1254,10 @@ describe("[FG5R] Events of system streams", () => {
             res = await request.delete(path.join(basePath, initialEvent.id))
               .set('authorization', access.token);
           });
-          it('[10EC] should return 400', () => { 
+          it('[10EC] should return 400', () => {
             assert.equal(res.status, 400);
           });
-          it('[D4CA] should return the correct error', () => { 
+          it('[D4CA] should return the correct error', () => {
             assert.equal(res.body.error.id, ErrorIds.InvalidOperation);
             assert.equal(res.body.error.message, ErrorMessages[ErrorIds.ForbiddenAccountEventModification]);
           });
@@ -1279,13 +1277,13 @@ describe("[FG5R] Events of system streams", () => {
             }).times(2).reply(200, { errors: [] });
           await createUser();
           initialEvent = await getOneEvent(user.attrs.id, streamId);
-  
+
           await createAdditionalEvent(streamId);
-  
+
           res = await request.delete(path.join(basePath, initialEvent.id))
             .set('authorization', access.token);
         });
-        it('[8EDB] should return a 400', () => { 
+        it('[8EDB] should return a 400', () => {
           assert.equal(res.status, 400);
         });
         it('[A727] should return the correct error', () => {
@@ -1359,6 +1357,6 @@ describe("[FG5R] Events of system streams", () => {
         assert.equal(res.body.error.id, ErrorIds.Forbidden);
       });
     });
-    
+
   });
 });

--- a/components/api-server/test/events-mutiple-streamIds.test.js
+++ b/components/api-server/test/events-mutiple-streamIds.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/*global describe, before, beforeEach, after, afterEach, it */
+/* global describe, before, beforeEach, after, afterEach, it */
 
 require('./test-helpers');
 
@@ -17,10 +17,7 @@ const assert = chai.assert;
 const charlatan = require('charlatan');
 const { integrity } = require('business');
 
-const helpers = require('./helpers');
-const validation = helpers.validation;
-
-const {fixturePath, fixtureFile} = require('./unit/test-helper');
+const { fixturePath } = require('./unit/test-helper');
 
 const { databaseFixture } = require('test-helpers');
 const { produceMongoConnection, context } = require('./test-helpers');
@@ -198,7 +195,7 @@ describe('events.streamIds', function () {
 
     });
 
-    describe('POST /events', function() { 
+    describe('POST /events', function() {
 
       it('[X4PX] must forbid to provide both streamId and streamIds', async function () {
         const res = await server.request()
@@ -294,8 +291,8 @@ describe('events.streamIds', function () {
       });
     });
 
-    describe('PUT /events/:id', function() { 
-      
+    describe('PUT /events/:id', function() {
+
       it('[BBBX] must return streamIds & streamId containing the first one (if many)', async function () {
         const res = await server.request()
           .put(eventPath(eventIdA))
@@ -332,7 +329,7 @@ describe('events.streamIds', function () {
         assert.equal(err.id, ErrorIds.InvalidOperation);
       });
 
-      describe('when modifying streamIds', function() { 
+      describe('when modifying streamIds', function() {
 
         it('[TQHG] must forbid providing an unknown streamId', async function () {
           const unknownStreamId = 'does-not-exist';
@@ -347,7 +344,7 @@ describe('events.streamIds', function () {
           assert.equal(err.id, ErrorIds.UnknownReferencedResource);
           assert.deepEqual(err.data, { streamIds: [unknownStreamId] });
         });
-  
+
         it('[6Q8B] must allow streamId addition, if you have a contribute permission for it', async function () {
           const res = await server.request()
             .put(eventPath(eventIdA))
@@ -360,7 +357,7 @@ describe('events.streamIds', function () {
           assert.equal(event.streamId, streamAId);
           assert.deepEqual(event.streamIds, [streamAId, streamBId]);
         });
-        
+
         it('[MFF7] must forbid streamId addition, if you don\'t have a contribute permission for it', async function () {
           const res = await server.request()
             .put(eventPath(eventIdA))
@@ -372,7 +369,7 @@ describe('events.streamIds', function () {
           const err = res.body.error;
           assert.equal(err.id, ErrorIds.Forbidden);
         });
-  
+
         it('[83N6] must allow streamId deletion, if you have a contribute permission for it', async function () {
           const res = await server.request()
             .put(eventPath(eventIdAB))
@@ -384,7 +381,7 @@ describe('events.streamIds', function () {
           const event = res.body.event;
           assert.deepEqual(event.streamIds, [streamAId]);
         });
-        
+
         it('[JLS5] must forbid streamId deletion, if you have read but no contribute permission for it', async function () {
           const res = await server.request()
             .put(eventPath(eventIdAB))
@@ -418,9 +415,9 @@ describe('events.streamIds', function () {
         const error = res.body.error;
         assert.equal(error.id, ErrorIds.Gone);
       });
-      
+
     });
-    
+
     describe('POST /event/stop', function () {
 
       function path() {
@@ -439,7 +436,7 @@ describe('events.streamIds', function () {
         const error = res.body.error;
         assert.equal(error.id, ErrorIds.Gone);
       });
-      
+
     });
 
     describe('DELETE /events/:id', function () {
@@ -488,18 +485,18 @@ describe('events.streamIds', function () {
     });
 
     describe('GET /events/:id/:fileId -- attachments', () => {
-      
+
       let userId, streamId, event,
-          appToken, appReadToken, 
+          appToken, appReadToken,
           sharedToken, sharedReadToken;
-    
+
       beforeEach(() => {
         userId = cuid();
         streamId = cuid();
         appToken = cuid();
         sharedToken = cuid();
       });
-    
+
       beforeEach(async () => {
         const user = await mongoFixtures.user(userId);
         await user.stream({
@@ -507,9 +504,9 @@ describe('events.streamIds', function () {
           name: streamId.toUpperCase(),
         });
         await user.access({
-          type: 'app', 
+          type: 'app',
           token: appToken,
-          name: charlatan.Lorem.word(), 
+          name: charlatan.Lorem.word(),
           permissions: [{
             streamId: streamId,
             level: 'manage',
@@ -518,14 +515,14 @@ describe('events.streamIds', function () {
         await user.access({
           type: 'shared',
           token: sharedToken,
-          name: charlatan.Lorem.word(), 
+          name: charlatan.Lorem.word(),
           permissions: [{
             streamId: streamId,
             level: 'read',
           }],
         });
       });
-    
+
       beforeEach(async () => {
         const res = await server.request()
           .post(path('events'))
@@ -547,7 +544,7 @@ describe('events.streamIds', function () {
       function path(resource) {
         return `/${userId}/${resource}`;
       }
-  
+
       it('[JNS8] should retrieve the attachment with the app token', async () => {
         const res = await server.request()
           .get(path(`events/${event.id}/${event.attachments[0].id}`))
@@ -568,7 +565,7 @@ describe('events.streamIds', function () {
         assert.equal(res.headers['content-disposition'], 'attachment; filename*=UTF-8\'\'' + event.attachments[0].fileName);
         assert.equal(res.headers['content-length'],event.attachments[0].size);
         assert.equal(res.headers['content-type'], event.attachments[0].type);
-      }); 
+      });
 
       it('[NH1O] should retrieve the attachment with the shared access readToken', async () => {
         const res = await server.request()
@@ -740,7 +737,7 @@ describe('events.streamIds', function () {
     describe('DELETE /streams', function () {
 
       describe('When the stream\'s event is part of at least another stream outside of its descendants', function () {
-      
+
         describe('when mergeEventsWithParent=false', function () {
 
           it('[TWDG] must not delete events, but remove the deleted streamId from their streamIds', async function () {
@@ -750,7 +747,7 @@ describe('events.streamIds', function () {
                 .set('Authorization', manageAccessToken)
                 .query({ mergeEventsWithParent: false });
             }
-      
+
             const res = await server.request()
               .get(pathEventId(eventIdA_AandB))
               .set('Authorization', manageAccessToken);
@@ -772,7 +769,7 @@ describe('events.streamIds', function () {
                 .set('Authorization', manageAccessToken)
                 .query({ mergeEventsWithParent: false });
             }
-      
+
             const res = await server.request()
               .get(basePathEvent)
               .set('Authorization', manageAccessToken)
@@ -800,12 +797,12 @@ describe('events.streamIds', function () {
                 .set('Authorization', manageAccessToken)
                 .query({ mergeEventsWithParent: true });
             }
-      
+
             const res = await server.request()
               .get(basePathEvent)
               .set('Authorization', manageAccessToken);
             assert.equal(res.body.events.length, 3);
-            
+
             let foundAandA_A = false;
             let foundA_AandA_A_A = false;
             let foundA_AandB = false;
@@ -831,7 +828,7 @@ describe('events.streamIds', function () {
 
         });
       });
-      
+
     });
   });
 });

--- a/components/api-server/test/hooks.js
+++ b/components/api-server/test/hooks.js
@@ -4,13 +4,13 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-var fs = require('fs');
+const fs = require('fs');
 const { getConfig } = require('@pryv/boiler');
 const util = require('util');
 
 let usersIndex, platform;
 
-async function initIndexPlatform() {
+async function initIndexPlatform () {
   if (usersIndex != null) return;
   usersIndex = require('business/src/users/UsersLocalIndex');
   platform = require('platform').platform;

--- a/components/api-server/test/permissions-create-only.test.js
+++ b/components/api-server/test/permissions-create-only.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/*global describe, it, before, after */
+/* global describe, it, before, after */
 
 const cuid = require('cuid');
 const chai = require('chai');
@@ -171,7 +171,7 @@ describe('permissions create-only level', () => {
       describe('GET /', function () {
 
         describe('when using an access with a "create-only" permissions', function () {
-  
+
           let accesses;
           before(async function () {
             const res = await server.request()
@@ -189,7 +189,7 @@ describe('permissions create-only level', () => {
       describe('POST /', function () {
 
         describe('when using an access with a "create-only" permission', function () {
-  
+
           it('[X4Z1] should allow to create an access with a "create-only" permissions', async function () {
             const res = await server.request()
               .post(basePath)
@@ -279,7 +279,7 @@ describe('permissions create-only level', () => {
           assert.equal(res.status, 410);
         });
       });
-  
+
       describe('DELETE /', function () {
         it('[G6IP] should forbid deleting accesses', async function () {
           const res = await server.request()
@@ -323,10 +323,10 @@ describe('permissions create-only level', () => {
           .get(basePath)
           .set('Authorization', coWithReadParentToken);
         const events = res.body.events;
-        assert.equal(events.length, 1); 
+        assert.equal(events.length, 1);
         for (const event of events) {
           assert.include(event.streamIds, streamParentId, 'Should only include "readable" streamId');
-        }     
+        }
       });
 
       it('[SYRW] should not return events when fetching "create-only" streams that are children of "contribute" streams', async function() {
@@ -335,10 +335,10 @@ describe('permissions create-only level', () => {
           .get(basePath)
           .set('Authorization', coWithContributeParentToken);
         const events = res.body.events;
-        assert.equal(events.length, 1); 
+        assert.equal(events.length, 1);
         for (let event of events) {
           assert.include(event.streamIds, streamParentId, 'Should only include "readable" streamId');
-        }  
+        }
       });
     });
 
@@ -381,7 +381,7 @@ describe('permissions create-only level', () => {
       });
     });
 
-    
+
 
     describe('PUT /', function () {
       it('[V0UO] should forbid updating events for "create-only" streams', async function () {
@@ -398,7 +398,7 @@ describe('permissions create-only level', () => {
       // skipping cases "... streams that are children of "read" streams" & "... streams that are children of "contribute" streams"
       // because they are covered by the GET above
     });
-    
+
     describe('DELETE /', function () {
       it('[5OUT] should forbid deleting events for "create-only" streams', async function () {
         const res = await server
@@ -429,7 +429,7 @@ describe('permissions create-only level', () => {
         eventId = res.body.event.id;
         fileId = res.body.event.fileId;
       });
-      
+
       // cleaning up explicitly as we are not using fixtures
       after(async function () {
         await server.request()
@@ -472,7 +472,7 @@ describe('permissions create-only level', () => {
         });
       });
     });
-    
+
   });
 
   describe('Streams', function() {

--- a/components/api-server/test/permissions-selfRevoke.test.js
+++ b/components/api-server/test/permissions-selfRevoke.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/*global describe, before, beforeEach, after, afterEach, it */
+/* global describe, before, beforeEach, after, afterEach, it */
 
 require('./test-helpers');
 
@@ -36,7 +36,7 @@ describe('permissions selfRevoke', function () {
     let username,
         personalToken,
         basePathAccess;
-    
+
     beforeEach(async function () {
       username = cuid();
       personalToken = cuid();
@@ -64,7 +64,7 @@ describe('permissions selfRevoke', function () {
           setting: 'forbidden'
         }]
       });
-      
+
       assert.equal(res.status, 201);
       assert.exists(res.body.access);
 
@@ -140,7 +140,7 @@ describe('permissions selfRevoke', function () {
             level: 'contribute'
           }]
         };
-        if (! access.selfRevoke) { 
+        if (! access.selfRevoke) {
           data.permissions.push({
             feature: 'selfRevoke',
             setting: 'forbidden'
@@ -167,6 +167,6 @@ describe('permissions selfRevoke', function () {
         }
       });
     }
-    
+
   });
 });

--- a/components/api-server/test/permissions-tags.test.js
+++ b/components/api-server/test/permissions-tags.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/*global describe, it, before, after */
+/* global describe, it, before, after */
 
 const cuid = require('cuid');
 const chai = require('chai');

--- a/components/api-server/test/registration-cluster.test.js
+++ b/components/api-server/test/registration-cluster.test.js
@@ -4,6 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
+/* global describe, it, before, after */
 // @flow
 
 const nock = require('nock');
@@ -60,7 +61,7 @@ describe('registration: cluster', function() {
     await mongoFixtures.context.cleanEverything();
   });
   before(async function () {
-    
+
     config.injectTestConfig({
       dnsLess: { isActive: false },
       openSource: { isActive: false },
@@ -75,7 +76,7 @@ describe('registration: cluster', function() {
 
     request = supertest(app.expressApp);
 
-    usersRepository = await getUsersRepository(); 
+    usersRepository = await getUsersRepository();
   });
   after(async function () {
     config.injectTestConfig({});
@@ -169,14 +170,14 @@ describe('registration: cluster', function() {
         res = await request.post(methodPath).send(userData);
         secondUser = await usersRepository.getUserByUsername(userData.username);
       });
-     
+
       it('[QV8Z] should respond with status 201', () => {
         assert.equal(res.status, 201);
       });
       it('[TCOM] should respond with the username and apiEndpoint', async () => {
         const body = res.body;
         assert.equal(body.username, userData.username);
-        const usersRepository = await getUsersRepository(); 
+        const usersRepository = await getUsersRepository();
         const user = await usersRepository.getUserByUsername(userData.username);
         const personalAccess = await bluebird.fromCallback(
           (cb) => app.storageLayer.accesses.findOne({ id: user.id }, {}, null, cb));
@@ -200,7 +201,7 @@ describe('registration: cluster', function() {
         secondRegistrationSent = stripRegistrationRequest(secondRegistrationSent);
         const secondRegistrationRequest = buildRegistrationRequest(userData);
         assert.deepEqual(secondRegistrationSent, secondRegistrationRequest, ' second registration request is invalid');
-        
+
         const users = [firstUser, secondUser];
         assert.equal(serviceRegisterRequestsPUT.length, users.length, 'should have recieved 2 PUT requests');
         for (let i = 0; i < serviceRegisterRequestsPUT.length ; i++) {
@@ -315,7 +316,7 @@ describe('registration: cluster', function() {
       it('[ZHYX] should send the right data to register', () => {
         // validate validation request - first and third requests
         // should be validation and they shuold be equal
-        //(remove core because validation and registration was done 
+        //(remove core because validation and registration was done
         // by different processes - port is different)
         let validationSent2 = Object.assign({}, serviceRegisterRequests[0]);
         delete validationSent2.core;
@@ -347,11 +348,11 @@ describe('registration: cluster', function() {
               data: { username: 'wactiv' }
             }
           });
-  
+
         res = await request.post(methodPath).send(userData);
       });
       it('[NUC9] should respond with status 409', () => {
-        assert.equal(res.status, 409);  
+        assert.equal(res.status, 409);
       });
       it('[X1IA] should respond with the correct error', () => {
         const error = res.body.error;
@@ -380,7 +381,7 @@ describe('registration: cluster', function() {
               data: { email: 'wactiv@pryv.io' }
             }
           });
-  
+
         res = await request.post(methodPath).send(userData);
       });
       it('[SJXN] should respond with status 409', () => {
@@ -404,7 +405,7 @@ describe('registration: cluster', function() {
           email: 'wactiv@pryv.io'
         });
         serviceRegisterRequests = [];
-  
+
         nock(regUrl)
           .post('/users/validate', (body) => {
             serviceRegisterRequests.push(body);
@@ -419,7 +420,7 @@ describe('registration: cluster', function() {
               }
             }
           });
-  
+
         res = await request.post(methodPath).send(userData);
       });
       it('[LUC6] should respond with status 409', () => {
@@ -442,7 +443,7 @@ describe('registration: cluster', function() {
       before(async () => {
         userData = defaults();
         serviceRegisterRequests = [];
-  
+
         nock(regUrl)
           .post('/users/validate', (body) => {
             serviceRegisterRequests.push(body);
@@ -456,7 +457,7 @@ describe('registration: cluster', function() {
               }
             }
           });
-  
+
         res = await request.post(methodPath).send(userData);
       });
       it('[I0HG] should respond with status 409', () => {
@@ -554,7 +555,7 @@ describe('registration: cluster', function() {
           //assert.deepEqual(registrationSent, buildRegistrationRequest(userData, false));
         });
       });
-    
+
     });
 
     describe('when invitationTokens are defined', () => {
@@ -700,9 +701,7 @@ describe('registration: cluster', function() {
     });
 
   });
-  
 
-  
+
+
 });
-
-

--- a/components/api-server/test/registration-dnsless.test.js
+++ b/components/api-server/test/registration-dnsless.test.js
@@ -20,7 +20,6 @@ const { pubsub } = require('messages');
 const { USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH } = require('api-server/src/schema/helpers');
 const ErrorIds = require('errors/src/ErrorIds');
 const { ApiEndpoint } = require('utils');
-const systemStreamsConfig = require('api-server/config/components/systemStreams');
 
 const cuid = require('cuid');
 
@@ -57,7 +56,7 @@ describe('[BMM2] registration: DNS-less', () => {
     };
     pubsub.setTestNotifier(axonSocket);
     await require("api-server/src/methods/events")(app.api);
-    
+
     request = supertest(app.expressApp);
   });
   describe('POST /users', () => {
@@ -71,7 +70,7 @@ describe('[BMM2] registration: DNS-less', () => {
         phoneNumber: charlatan.Number.number(3),
       };
     }
-    
+
     describe('when given valid input', function() {
       let registerData;
       before(async function() {
@@ -84,7 +83,7 @@ describe('[BMM2] registration: DNS-less', () => {
       });
       it('[VDA8] should respond with a username and apiEndpoint in the request body', async () => {
         assert.equal(res.body.username, registerData.username);
-        const usersRepository = await getUsersRepository(); 
+        const usersRepository = await getUsersRepository();
         const user = await usersRepository.getUserByUsername(registerData.username);
         const personalAccess = await bluebird.fromCallback(
           (cb) => app.storageLayer.accesses.findOne({ id: user.id }, {}, null, cb));
@@ -107,20 +106,20 @@ describe('[BMM2] registration: DNS-less', () => {
       describe(
         'when given an invalid username parameter',
         testInvalidParameterValidation(
-          'username', 
+          'username',
           {
             minLength: USERNAME_MIN_LENGTH,
             maxLength: USERNAME_MAX_LENGTH,
             lettersAndDashesOnly: true,
             type: 'string',
-          }, 
+          },
           ['G81N','JQ7V','EIKE','XTD0','TSC6','TL2W','MST7','WG46','M6CD','3Q1H'],
         )
       );
       describe(
         'when given an invalid password parameter',
         testInvalidParameterValidation(
-          'password', 
+          'password',
           {
             minLength: 4,
             maxLength: 100,
@@ -142,7 +141,7 @@ describe('[BMM2] registration: DNS-less', () => {
       describe(
         'when given an invalid appId parameter',
         testInvalidParameterValidation(
-          'appId', 
+          'appId',
           {
             minLength: 6,
             maxLength: 99,
@@ -154,7 +153,7 @@ describe('[BMM2] registration: DNS-less', () => {
       describe(
         'when given an invalid invitationToken parameter',
         testInvalidParameterValidation(
-          'invitationToken', 
+          'invitationToken',
           {
             type: 'string',
           },
@@ -164,7 +163,7 @@ describe('[BMM2] registration: DNS-less', () => {
       describe(
         'when given an invalid referer parameter',
         testInvalidParameterValidation(
-          'referer', 
+          'referer',
           {
             maxLength: 99,
             type: 'string',
@@ -176,7 +175,7 @@ describe('[BMM2] registration: DNS-less', () => {
       describe(
         'when given an invalid language parameter',
         testInvalidParameterValidation(
-          'language', 
+          'language',
           {
             minLength: 1,
             maxLength: 5,
@@ -200,7 +199,7 @@ describe('[BMM2] registration: DNS-less', () => {
           res = await request.post('/users').send(registerData1ReuseEmail);
           assert.equal(res.status, 201);
 
-          // create a user with the same username and email from two other users 
+          // create a user with the same username and email from two other users
           registerData = generateRegisterBody();
           registerData.username = registerData1ReuseUsername.username;
           registerData.email = registerData1ReuseEmail.email;
@@ -213,7 +212,7 @@ describe('[BMM2] registration: DNS-less', () => {
         it('[M2HD] should respond with the correct error message', function() {
           assert.exists(res.error);
           assert.exists(res.error.text);
-          
+
           // changed to new error format to match the cluster
           const error = JSON.parse(res.error.text);
           assert.deepEqual(error.error.data, { username: registerData.username, email: registerData.email });

--- a/components/api-server/test/service-reporting.test.js
+++ b/components/api-server/test/service-reporting.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/* global describe, beforeEach, afterEach, it */
+/* global describe, it, before, after */
 
 require('./test-helpers');
 const httpServer = require('./support/httpServer');
@@ -41,7 +41,7 @@ describe('service-reporting', () => {
   before(async function() {
     mongoFixtures = databaseFixture(await produceMongoConnection());
     if ((await getConfig()).get('openSource:isActive')) this.skip();
-    
+
   });
   after(async () => {
     await mongoFixtures.clean();

--- a/components/api-server/test/system.test.js
+++ b/components/api-server/test/system.test.js
@@ -5,9 +5,9 @@
  * Proprietary and confidential
  */
 
-/*global describe, before, beforeEach, after, it */
+/* global describe, before, beforeEach, after, it */
 
-require('./test-helpers'); 
+require('./test-helpers');
 
 const async = require('async');
 const should = require('should');
@@ -15,7 +15,7 @@ const request = require('superagent');
 const timestamp = require('unix-timestamp');
 const url = require('url');
 const _ = require('lodash');
-const assert = require('chai').assert; 
+const assert = require('chai').assert;
 const bluebird = require('bluebird');
 const os = require('os');
 const fs = require('fs');
@@ -26,7 +26,6 @@ const server = helpers.dependencies.instanceManager;
 const methodsSchema = require('../src/schema/systemMethods');
 const validation = helpers.validation;
 const encryption = require('utils').encryption;
-const storage = helpers.dependencies.storage.user.events;
 const testData = helpers.data;
 const { getUsersRepository } = require('business/src/users');
 const { databaseFixture } = require('test-helpers');
@@ -39,8 +38,8 @@ require('date-utils');
 
 describe('system route', function () {
   let mongoFixtures,
-    username, 
-    server, 
+    username,
+    server,
     config;
 
   before(async function() {
@@ -58,7 +57,7 @@ describe('system route', function () {
     await mongoFixtures.user(username, {});
   });
 
-  it('[JT1A] should parse correctly usernames starting with "system"', async () => { 
+  it('[JT1A] should parse correctly usernames starting with "system"', async () => {
     const res = await server.request().get('/' + username + '/events')
       .set('authorization', 'dummy');
     should.exist(res.body.error);
@@ -82,7 +81,7 @@ describe('system route', function () {
 
   describe('DELETE /mfa', () => {
     let username, mfaPath, profilePath, res, profileRes, token, restOfProfile;
-    
+
     before(async () => {
       username = charlatan.Lorem.characters(10);
       token = cuid();
@@ -98,7 +97,7 @@ describe('system route', function () {
       const res = await server.request()
         .put(profilePath)
         .set('authorization', token)
-        .send({ 
+        .send({
           mfa: { content: { phone: '123' }, recoveryCodes: ['1', '2', '3']},
           restOfProfile,
         });
@@ -124,7 +123,7 @@ describe('system route', function () {
 
 describe('system (ex-register)', function () {
   let mongoFixtures;
-  
+
   this.timeout(5000);
   function basePath() {
     return url.resolve(server.url, '/system');
@@ -148,7 +147,7 @@ describe('system (ex-register)', function () {
   // NOTE: because we mock the email sending service for user creation and to
   // keep test code simple, test order is important. The first test configures
   // the mock service in order to test email sending, the second one
-  // reconfigures it so that it just replies OK for subsequent tests.   
+  // reconfigures it so that it just replies OK for subsequent tests.
   describe('POST /create-user', function () {
 
     function path() {
@@ -180,9 +179,9 @@ describe('system (ex-register)', function () {
         };
 
         let mailSent = false;
-        
+
         let originalCount;
-            
+
         // setup mail server mock
         helpers.instanceTestSetup.set(settings, {
           context: settings.services.email,
@@ -202,7 +201,7 @@ describe('system (ex-register)', function () {
         });
         await (new Promise(server.ensureStarted.bind(server, settings)));
 
-        const usersRepository = await getUsersRepository(); 
+        const usersRepository = await getUsersRepository();
         const originalUsers = await usersRepository.getAll();
 
         originalCount = originalUsers.length;
@@ -232,7 +231,7 @@ describe('system (ex-register)', function () {
         account.should.eql(expected);
       });
     });
-    
+
     it('[0G7C] must not send a welcome email if mailing is deactivated', function (done) {
       let settings = _.cloneDeep(helpers.dependencies.settings);
       settings.services.email.enabled = false;
@@ -245,7 +244,7 @@ describe('system (ex-register)', function () {
       };
       testWelcomeMailNotSent(settings, done);
     });
-    
+
     function testWelcomeMailNotSent (settings, callback) {
       // setup mail server mock
       helpers.instanceTestSetup.set(settings, {
@@ -257,7 +256,7 @@ describe('system (ex-register)', function () {
             }.bind(this));
         }
       });
-      
+
       // fetch notification from server process
       server.once('mail-sent2', function () {
         return callback('Welcome email should not be sent!');
@@ -282,14 +281,14 @@ describe('system (ex-register)', function () {
     describe('when it just replies OK', function() {
       before(server.ensureStarted.bind(server, helpers.dependencies.settings));
 
-      it('[9K71] must run the process but not save anything for test username "recla"', 
+      it('[9K71] must run the process but not save anything for test username "recla"',
         async function () {
           var originalCount,
               createdUserId,
               settings = _.cloneDeep(helpers.dependencies.settings);
-    
+
           should(process.env.NODE_ENV).be.eql('test');
-    
+
           // setup mail server mock, persisting over the next tests
           helpers.instanceTestSetup.set(settings, {
             context: settings.services.email,
@@ -302,7 +301,7 @@ describe('system (ex-register)', function () {
 
           await (new Promise(server.ensureStarted.bind(server, settings)));
 
-          const usersRepository = await getUsersRepository(); 
+          const usersRepository = await getUsersRepository();
           originalUsers = await usersRepository.getAll();
           originalCount = originalUsers.length;
 
@@ -326,7 +325,7 @@ describe('system (ex-register)', function () {
           users.length.should.eql(originalCount, 'users');
           should.not.exist(_.find(users, { id: createdUserId }));
         });
-    
+
       it('[ZG1L] must support the old "/register" path for backwards-compatibility', function (done) {
         let newUserDataExpected = Object.assign({}, newUserData);
         request.post(url.resolve(server.url, '/register/create-user'))
@@ -338,7 +337,7 @@ describe('system (ex-register)', function () {
             }, done);
           });
       });
-    
+
       it('[VGF5] must return a correct 400 error if the sent data is badly formatted', function (done) {
         post({ badProperty: 'bad value' }, function (err, res) {
           validation.checkErrorInvalidParams(res, done);
@@ -358,7 +357,7 @@ describe('system (ex-register)', function () {
           validation.checkErrorInvalidParams(res, done);
         });
       });
-    
+
       it('[RD10] must return a correct 400 error if a user with the same user name already exists',
         async function () {
           var data = {
@@ -397,7 +396,7 @@ describe('system (ex-register)', function () {
           assert.deepEqual(err.response.body.error.data, { email: data.email });
         }
       });
-    
+
       it('[Y5JB] must return a correct 404 error when authentication is invalid', function (done) {
         let newUserDataExpected = Object.assign({}, newUserData);
         request
@@ -410,7 +409,7 @@ describe('system (ex-register)', function () {
             }, done);
           });
       });
-    
+
       it('[GF3L] must return a correct error if the content type is wrong', function (done) {
         request.post(path())
           .set('authorization', helpers.dependencies.settings.auth.adminAccessKey)
@@ -424,9 +423,9 @@ describe('system (ex-register)', function () {
       });
     });
     describe('when we log into a temporary log file', function () {
-    
+
       let logFilePath = '';
-    
+
       beforeEach(function (done) {
         async.series([
           ensureLogFileIsEmpty,
@@ -434,7 +433,7 @@ describe('system (ex-register)', function () {
           instanciateServerWithLogs
         ], done);
       });
-    
+
       function ensureLogFileIsEmpty(stepDone) {
         if ( logFilePath.length <= 0 ) return stepDone();
         fs.truncate(logFilePath, function (err) {
@@ -444,12 +443,12 @@ describe('system (ex-register)', function () {
           stepDone(err);
         });
       }
-    
+
       function generateLogFile(stepDone) {
         logFilePath = os.tmpdir() + '/password-logs.log';
         stepDone();
       }
-    
+
       function instanciateServerWithLogs(stepDone) {
         let settings = _.cloneDeep(helpers.dependencies.settings);
         settings.logs = {
@@ -464,9 +463,9 @@ describe('system (ex-register)', function () {
         };
         server.ensureStarted.call(server, settings, stepDone);
       }
-    
+
       after(server.ensureStarted.bind(server,helpers.dependencies.settings));
-    
+
       // cf. GH issue #64
       it('[Y69B] must replace the passwordHash in the logs by (hidden) when the authentication is invalid', function (done) {
         let newUserDataExpected = Object.assign({}, newUserData);
@@ -483,7 +482,7 @@ describe('system (ex-register)', function () {
           verifyHiddenPasswordHashInLogs
         ], done);
       });
-    
+
       // cf. GH issue #64 too
       it('[MEJ9] must replace the passwordHash in the logs by (hidden) when the payload is invalid (here parameters)', function (done) {
         let newUserDataExpected = Object.assign({}, newUserData);
@@ -499,14 +498,14 @@ describe('system (ex-register)', function () {
           verifyHiddenPasswordHashInLogs
         ], done);
       });
-    
+
       it('[CO6H] must not mention the passwordHash in the logs when none is provided', function (done) {
         let newUserDataExpected = Object.assign({}, newUserData);
         async.series([
           function failCreateUser(stepDone) {
             let dataWithNoPasswordHash = _.cloneDeep(newUserDataExpected);
             delete dataWithNoPasswordHash.passwordHash;
-    
+
             post(dataWithNoPasswordHash, function (err, res) {
               validation.checkError(res, {
                 status: 400,
@@ -517,7 +516,7 @@ describe('system (ex-register)', function () {
           verifyNoPasswordHashFieldInLogs
         ], done);
       });
-    
+
       function verifyHiddenPasswordHashInLogs (callback) {
         let newUserDataExpected = Object.assign({}, newUserData);
         fs.readFile(logFilePath, 'utf8', function (err, data) {
@@ -530,7 +529,7 @@ describe('system (ex-register)', function () {
           callback();
         });
       }
-    
+
       function verifyNoPasswordHashFieldInLogs(callback) {
         fs.readFile(logFilePath, 'utf8', function (err, data) {
           if (err) {
@@ -540,7 +539,7 @@ describe('system (ex-register)', function () {
           callback();
         });
       }
-    
+
     });
 
   });
@@ -590,26 +589,26 @@ describe('system (ex-register)', function () {
             .set('authorization', helpers.dependencies.settings.auth.adminAccessKey)
             .end(function (err, res) {
               const info = res.body.userInfo;
-              
+
               assert.approximately(info.lastAccess, expectedTime, 2);
-              
+
               info.callsTotal
-                .should.eql(originalInfo.callsTotal + 2, 
+                .should.eql(originalInfo.callsTotal + 2,
                   'calls total');
               info.callsDetail['events:get']
-                .should.eql(originalInfo.callsDetail['events:get'] + 2, 
+                .should.eql(originalInfo.callsDetail['events:get'] + 2,
                   'calls detail');
-                
+
               const accessKey1 = testData.accesses[4].name; // app access
               const accessKey2 = 'shared';                  // shared access
-              
+
               info.callsPerAccess[accessKey1]
-                .should.eql(originalInfo.callsPerAccess[accessKey1] + 1, 
+                .should.eql(originalInfo.callsPerAccess[accessKey1] + 1,
                   'calls per access (personal)');
               info.callsPerAccess[accessKey2]
                 .should.eql(originalInfo.callsPerAccess[accessKey2] + 1,
                   'calls per access (shared)');
-                
+
               stepDone();
             });
         }

--- a/components/api-server/test/webhooks.test.js
+++ b/components/api-server/test/webhooks.test.js
@@ -4,7 +4,7 @@
  * Unauthorized copying of this file, via any medium is strictly prohibited
  * Proprietary and confidential
  */
-/*global describe, it, before, after */
+/* global describe, it, before, after */
 
 const cuid = require('cuid');
 const bluebird = require('bluebird');
@@ -34,7 +34,7 @@ describe('webhooks', () => {
     await mongoFixtures.clean();
   });
 
-  let username, personalAccessToken, 
+  let username, personalAccessToken,
       appAccessToken1, appAccessToken2,
       appAccessId1, appAccessId2,
       sharedAccessToken,
@@ -75,7 +75,7 @@ describe('webhooks', () => {
           type: 'app', token: appAccessToken2,
         });
         user.access({
-          type: 'shared', token: sharedAccessToken, 
+          type: 'shared', token: sharedAccessToken,
         });
 
         user.session(personalAccessToken);
@@ -83,13 +83,13 @@ describe('webhooks', () => {
         user.webhook({}, appAccessId2);
       });
     });
-    
+
     after(async () => {
       await mongoFixtures.clean();
     });
 
     describe('when using an app token', () => {
-      
+
       let webhooks, response;
       before(async () => {
         const res = await server.request()
@@ -116,7 +116,7 @@ describe('webhooks', () => {
         });
       });
     });
-    
+
     describe('when using a personal token', () => {
 
       let webhooks, response;
@@ -137,14 +137,14 @@ describe('webhooks', () => {
 
       it('[4YFQ] should fetch all webhooks for the user', () => {
         let found1 = false;
-        let found2 = false; 
+        let found2 = false;
         webhooks.forEach(w => {
           if (w.accessId === appAccessId1) {
             found1 = true;
-          } 
+          }
           if (w.accessId === appAccessId2) {
             found2 = true;
-          } 
+          }
         });
         assert.isTrue(found1, 'did not find webhook1');
         assert.isTrue(found2, 'did not find webhook2');
@@ -270,7 +270,7 @@ describe('webhooks', () => {
           validation.checkErrorUnknown(response);
         });
       });
-    
+
     });
 
     describe('when using a personal token', () => {
@@ -288,7 +288,7 @@ describe('webhooks', () => {
           status: 200,
         });
       });
-    });    
+    });
 
     describe('when using a shared token', () => {
 
@@ -461,7 +461,7 @@ describe('webhooks', () => {
       });
     });
 
-    describe('when using a personal token', () => {     
+    describe('when using a personal token', () => {
 
       describe('when providing a valid webhook', () => {
         let response;
@@ -479,7 +479,7 @@ describe('webhooks', () => {
       });
     });
 
-    
+
 
   });
 
@@ -948,7 +948,7 @@ describe('webhooks', () => {
       describe('when the webhook exists', () => {
 
         describe('when the URL is valid', () => {
-          
+
           let response;
           before(async () => {
             response = await server.request()
@@ -986,7 +986,7 @@ describe('webhooks', () => {
             });
           });
         });
-        
+
       });
 
       describe('when the webhook does not exist', () => {

--- a/components/business/src/system-streams/serializer.js
+++ b/components/business/src/system-streams/serializer.js
@@ -29,7 +29,7 @@ let singleton = null;
 
 /**
  * Class that converts system->account events to the
- * Account information that matches the previous 
+ * Account information that matches the previous
  * structure of the account info
  */
 class SystemStreamsSerializer {
@@ -48,7 +48,7 @@ class SystemStreamsSerializer {
   static allAsTree: ?Array<SystemStream>;
   static allMap: ?Map<string, boolean>;
   static allStreamIds: ?Array<string>;
-  
+
   static readable: ?Array<Stream>;
 
   static readableAccountMap: ?Map<string, SystemStream>;
@@ -69,7 +69,7 @@ class SystemStreamsSerializer {
   static accountStreamsIdsForbiddenForReading: ?Array<string>;
 
   static allRootStreamIdsThatRequireReadRightsForEventsGet: ?Array<string>;
-  
+
   static accountChildren: ?Array<SystemStream>;
 
   // Maps used for quick translation from without prefix to with
@@ -104,7 +104,7 @@ class SystemStreamsSerializer {
     }
     singleton = new SystemStreamsSerializer();
     singleton.systemStreamsSettings = config.get('systemStreams');
-    
+
     this.allAsTree = null;
     this.allMap = null;
     this.allStreamIds = null;
@@ -131,11 +131,11 @@ class SystemStreamsSerializer {
   }
 
   constructor () {
-   
+
   }
 
   /**
-   * Get all root streamIds that need explicit rights to be readable (all stream starting by PRYV_PRFIX) 
+   * Get all root streamIds that need explicit rights to be readable (all stream starting by PRYV_PRFIX)
    */
   static getAllRootStreamIdsThatRequireReadRightsForEventsGet (): Array<string> {
     if (SystemStreamsSerializer.allRootStreamIdsThatRequireReadRightsForEventsGet) return SystemStreamsSerializer.allRootStreamIdsThatRequireReadRightsForEventsGet;
@@ -183,11 +183,11 @@ class SystemStreamsSerializer {
    */
   static getReadableAccountMapForTests(): Map<string, SystemStream> {
     if ( SystemStreamsSerializer.readableAccountMapForTests != null ) return SystemStreamsSerializer.readableAccountMapForTests;
-    
+
     const streams = filterMapStreams(SystemStreamsSerializer.getAccountChildren(), IS_SHOWN);
     delete streams[SystemStreamsSerializer.addPrivatePrefixToStreamId('storageUsed')];
     SystemStreamsSerializer.readableAccountMapForTests = streams;
-    
+
     return SystemStreamsSerializer.readableAccountMapForTests;
   }
 
@@ -196,7 +196,7 @@ class SystemStreamsSerializer {
    */
   static getEditableAccountMap(): Map<string, SystemStream> {
     if ( SystemStreamsSerializer.editableAccountMap != null ) return SystemStreamsSerializer.editableAccountMap;
-    
+
     SystemStreamsSerializer.editableAccountMap = filterMapStreams(SystemStreamsSerializer.getAccountChildren(), IS_EDITABLE);
 
     return SystemStreamsSerializer.editableAccountMap;
@@ -204,11 +204,11 @@ class SystemStreamsSerializer {
 
 
   /**
-   * Get only those streams that user is allowed to edit 
+   * Get only those streams that user is allowed to edit
    */
   static getEditableAccountStreamIds(): Array<string> {
     if ( SystemStreamsSerializer.editableAccountStreamIds != null ) return SystemStreamsSerializer.editableAccountStreamIds;
-    
+
     SystemStreamsSerializer.editableAccountStreamIds = Object.keys(SystemStreamsSerializer.getEditableAccountMap());
 
     return SystemStreamsSerializer.editableAccountStreamIds;
@@ -217,13 +217,13 @@ class SystemStreamsSerializer {
   /**
    * Returns account system streams
    * streamId -> stream
-   * 
-   * should be used only for internal usage because contains fields that 
+   *
+   * should be used only for internal usage because contains fields that
    * should not be returned to the user
    */
   static getAccountMap(): Map<string, SystemStream> {
     if ( SystemStreamsSerializer.accountMap != null ) return SystemStreamsSerializer.accountMap;
-    
+
     SystemStreamsSerializer.accountMap = filterMapStreams(SystemStreamsSerializer.getAccountChildren(), ALL);
     return SystemStreamsSerializer.accountMap;
   }
@@ -231,24 +231,24 @@ class SystemStreamsSerializer {
   /**
    * Returns keys of getAccountMap
    * streamId -> stream
-   * 
-   * should be used only for internal usage because contains fields that 
+   *
+   * should be used only for internal usage because contains fields that
    * should not be returned to the user
    */
   static getAccountStreamIds(): Array<string> {
     if ( SystemStreamsSerializer.accountStreamIds != null ) return SystemStreamsSerializer.accountStreamIds;
-    
+
     SystemStreamsSerializer.accountStreamIds = Object.keys(SystemStreamsSerializer.getAccountMap());
     return SystemStreamsSerializer.accountStreamIds;
   }
 
   /**
    * Similar to getAccountMap, but the result gets organized into categories:
-   * 
+   *
    */
   static getAccountStreamIdsForUser(): Map<string, Array<string>> {
     if ( SystemStreamsSerializer.allAccountStreamIdsForUser != null ) return SystemStreamsSerializer.allAccountStreamIdsForUser;
-    
+
     const returnObject = {};
     returnObject.uniqueAccountFields = [];
     returnObject.readableAccountFields = [];
@@ -256,7 +256,7 @@ class SystemStreamsSerializer {
     returnObject.accountFieldsWithPrefix = [];
 
     const accountStreams = SystemStreamsSerializer.getAccountMap();
-    
+
     Object.keys(accountStreams).forEach(streamId => {
       returnObject.accountFieldsWithPrefix.push(streamId);
       const streamIdWithoutPrefix = SystemStreamsSerializer.removePrefixFromStreamId(streamId);
@@ -265,11 +265,11 @@ class SystemStreamsSerializer {
       }
       if (accountStreams[streamId].isShown == true) {
         returnObject.readableAccountFields.push(streamIdWithoutPrefix);
-      }    
+      }
       returnObject.accountFields.push(streamIdWithoutPrefix);
     });
     SystemStreamsSerializer.allAccountStreamIdsForUser = returnObject;
-    
+
     return SystemStreamsSerializer.allAccountStreamIdsForUser;
   }
 
@@ -307,7 +307,7 @@ class SystemStreamsSerializer {
   /**
    * Returns null or default value
    */
-   static getAccountFieldDefaultValue(fieldId: string): boolean {
+  static getAccountFieldDefaultValue(fieldId: string): boolean {
     return SystemStreamsSerializer.getAllMap()[PRYV_PREFIX + fieldId]?.default;
   }
 
@@ -315,8 +315,8 @@ class SystemStreamsSerializer {
    * The same as getAccountMap () but returnes only streams leaves (not parents)
    */
   static getAccountLeavesMap(): Map<string, SystemStream> {
-    if (SystemStreamsSerializer.accountLeavesMap != null) return SystemStreamsSerializer.accountLeavesMap
-      
+    if (SystemStreamsSerializer.accountLeavesMap != null) return SystemStreamsSerializer.accountLeavesMap;
+
     const flatStreamsList = treeUtils.flattenTreeWithoutParents(SystemStreamsSerializer.getAccountChildren());
     let streamsMap = {};
 
@@ -335,7 +335,7 @@ class SystemStreamsSerializer {
     let indexedStreamIds = Object.keys(filterMapStreams(SystemStreamsSerializer.getAccountChildren(), IS_INDEXED));
     SystemStreamsSerializer.indexedAccountStreamsIdsWithoutPrefix = indexedStreamIds.map(
       streamId => {
-        return SystemStreamsSerializer.removePrefixFromStreamId(streamId)
+        return SystemStreamsSerializer.removePrefixFromStreamId(streamId);
       }
     );
     return SystemStreamsSerializer.indexedAccountStreamsIdsWithoutPrefix;
@@ -357,7 +357,7 @@ class SystemStreamsSerializer {
     const uniqueStreamIds = Object.keys(filterMapStreams(SystemStreamsSerializer.getAccountChildren(), IS_UNIQUE));
     SystemStreamsSerializer.uniqueAccountStreamsIdsWithoutPrefix =
       uniqueStreamIds.map(streamId => {
-        return SystemStreamsSerializer.removePrefixFromStreamId(streamId)
+        return SystemStreamsSerializer.removePrefixFromStreamId(streamId);
     });
     return SystemStreamsSerializer.uniqueAccountStreamsIdsWithoutPrefix;
   }
@@ -374,7 +374,7 @@ class SystemStreamsSerializer {
       Object.keys(accountMap),
       Object.keys(readableStreams),
     );
-    
+
     return SystemStreamsSerializer.accountStreamsIdsForbiddenForReading;
   }
 
@@ -401,7 +401,7 @@ class SystemStreamsSerializer {
   /**
    * Checks if a streamId starts with a system stream prefix. To be used only in accesses.create!
    * Don't let prefix checks leak into the code, use maps instead for performance and readability.
-   * @param {string} streamIdWithPrefix 
+   * @param {string} streamIdWithPrefix
    */
   static hasSystemStreamPrefix(streamIdWithPrefix: string): boolean {
     return streamIdWithPrefix.startsWith(PRYV_PREFIX) || streamIdWithPrefix.startsWith(CUSTOMER_PREFIX);
@@ -413,7 +413,7 @@ class SystemStreamsSerializer {
   */
   static addPrivatePrefixToStreamId(streamId: string): string {
     const streamIdWithPrefix = SystemStreamsSerializer.privateStreamIdWithoutPrefixToWith[streamId];
-    if (streamIdWithPrefix == null) throw new Error('trying to call addCustomerPrefixToStreamId() with non-private streamId: ' + streamId)
+    if (streamIdWithPrefix == null) throw new Error('trying to call addCustomerPrefixToStreamId() with non-private streamId: ' + streamId);
     return streamIdWithPrefix;
   }
 
@@ -427,7 +427,7 @@ class SystemStreamsSerializer {
   */
   static addCustomerPrefixToStreamId(streamId: string): string {
     const streamIdWithPrefix = SystemStreamsSerializer.customerStreamIdWithoutPrefixToWith[streamId];
-    if (streamIdWithPrefix == null) throw new Error('trying to call addCustomerPrefixToStreamId() with non-customer streamId: ' + streamId)
+    if (streamIdWithPrefix == null) throw new Error('trying to call addCustomerPrefixToStreamId() with non-customer streamId: ' + streamId);
     return streamIdWithPrefix;
   }
 
@@ -478,13 +478,13 @@ class SystemStreamsSerializer {
 /**
  * Filters streams and returns them as a Map:
  * streamId -> stream
- * 
+ *
  * @param Array<SysteamStream> streams - tree of system streams
  * @param string filter - boolean value used for filtering
  */
 function filterMapStreams (streams: Array<SystemStream>, filter: string = IS_SHOWN): Map<string, SystemStream> {
   let streamsMap: Map<string, SystemStream> = {};
-  
+
   if (! Array.isArray(streams)) {
     return streamsMap;
   }
@@ -492,9 +492,9 @@ function filterMapStreams (streams: Array<SystemStream>, filter: string = IS_SHO
 
   // convert list to objects
   for (let i = 0; i < flatStreamsList.length; i++){
-    
+
     if (filter === ALL || flatStreamsList[i][filter]) {
-      streamsMap[flatStreamsList[i].id] = flatStreamsList[i]
+      streamsMap[flatStreamsList[i].id] = flatStreamsList[i];
     } else {
       // escape it
     }
@@ -557,8 +557,8 @@ function initializeSerializer(serializer) {
 /**
  * Removes the prefix from the streamId
  * Only to be used at initialization!
- * 
- * @param streamId 
+ *
+ * @param streamId
  */
 function _removePrefixFromStreamId(streamId: string): string {
   if (streamId.startsWith(PRYV_PREFIX)) return streamId.substr(PRYV_PREFIX.length);

--- a/components/business/src/users/UsersLocalIndex.js
+++ b/components/business/src/users/UsersLocalIndex.js
@@ -8,14 +8,11 @@
  * Contains UserName >> UserId Mapping
  */
 
-const cuid = require('cuid');
-const bluebird = require('bluebird');
 const mkdirp = require('mkdirp');
 const sqlite3 = require('better-sqlite3');
 
 const { getLogger, getConfig } = require('@pryv/boiler');
 const cache = require('cache');
-const SystemStreamsSerializer = require('business/src/system-streams/serializer');
 
 const userLocalIndexCheckIntegrity = require('./userLocalIndexCheckIntegrity');
 
@@ -30,14 +27,11 @@ class UsersLocalIndex {
   }
 
   async init() {
-    if (this.initialized) { return };
+    if (this.initialized) { return; }
     this.initialized = true;
 
     this.db = new DBIndex();
     await this.db.init();
-
-    const storage = require('storage');
-    const storageLayer = await storage.getStorageLayer();
 
     logger.debug('init');
   }
@@ -63,7 +57,7 @@ class UsersLocalIndex {
       userId = this.db.getIdForName(username);
       if (userId != null) {
         cache.setUserId(username, userId);
-      } 
+      }
     }
     logger.debug('idForName', username, userId);
     return userId;
@@ -80,7 +74,7 @@ class UsersLocalIndex {
     return this.db.allUsersMap();
   }
 
-  // reset everything -- used by tests only 
+  // reset everything -- used by tests only
   async deleteAll() {
     logger.debug('deleteAll');
     cache.clear();
@@ -109,10 +103,9 @@ class DBIndex {
     const basePath = config.get('userFiles:path');
     mkdirp.sync(basePath);
 
-    const DB_OPTIONS = {};
     this.db = new sqlite3(basePath + '/user-index.db');
     this.db.pragma('journal_mode = WAL');
-    
+
     this.db.prepare('CREATE TABLE IF NOT EXISTS id4name (username TEXT PRIMARY KEY, userId TEXT NOT NULL);').run();
     this.db.prepare('CREATE INDEX IF NOT EXISTS id4name_id ON id4name(userId);').run();
 

--- a/components/business/test/unit/users/repository.test.js
+++ b/components/business/test/unit/users/repository.test.js
@@ -9,9 +9,8 @@ const chai = require('chai');
 const assert = chai.assert;
 const charlatan = require('charlatan');
 require('test-helpers/src/api-server-tests-config');
-const helpers = require('api-server/test/helpers');
 const { databaseFixture } = require('test-helpers');
-const { produceMongoConnection, context } = require('api-server/test/test-helpers');
+const { produceMongoConnection } = require('api-server/test/test-helpers');
 const { getUsersRepository, User } = require('business/src/users');
 const { ErrorIds } = require('errors');
 
@@ -24,7 +23,6 @@ describe('Users repository', () => {
   after(async () => {
     await mongoFixtures.clean();
   });
-  let userId;
   let username;
   let email;
   let customRegistrationUniqueField;
@@ -50,7 +48,7 @@ describe('Users repository', () => {
 
     it('[7C22] must throw an item already exists error when username field is not unique', async () => {
       try {
-        const usersRepository = await getUsersRepository(); 
+        const usersRepository = await getUsersRepository();
         const userObj: User = new User({
           id: charlatan.Lorem.characters(10),
           username,
@@ -68,7 +66,7 @@ describe('Users repository', () => {
 
     it('[6CFE] must throw an item already exists error when email field is not unique', async () => {
       try {
-        const usersRepository = await getUsersRepository(); 
+        const usersRepository = await getUsersRepository();
         const userObj: User = new User({
           id: charlatan.Lorem.characters(10),
           username: charlatan.Lorem.characters(10),

--- a/components/platform/src/DB.js
+++ b/components/platform/src/DB.js
@@ -22,7 +22,6 @@ class DB {
     const basePath = config.get('userFiles:path');
     mkdirp.sync(basePath);
 
-    const DB_OPTIONS = {};
     this.db = new sqlite3(basePath + '/platform-wide.db');
     this.db.pragma('journal_mode = WAL');
 
@@ -55,10 +54,10 @@ class DB {
   }
 
   /**
-   * 
+   *
    * @param {string} key
-   * @param {string} value 
-   * @returns 
+   * @param {string} value
+   * @returns
    */
   set(key, value) {
     logger.debug('set', key, value);
@@ -114,8 +113,8 @@ class DB {
 
 /**
  * Return an object from an entry in the table
- * @param {Entry} entry 
- * @param {string} entry.key 
+ * @param {Entry} entry
+ * @param {string} entry.key
  * @param {string} entry.value
  */
 function parseEntry(entry) {
@@ -126,7 +125,7 @@ function parseEntry(entry) {
     field: field,
     username: isUnique ? entry.value : userNameOrValue,
     value: isUnique ? userNameOrValue : entry.value
-  }
+  };
 }
 
 function getUserUniqueKey(field, value) {

--- a/components/platform/src/platformCheckIntegrity.js
+++ b/components/platform/src/platformCheckIntegrity.js
@@ -43,7 +43,7 @@ module.exports = async function platformCheckIntegrity (platformWideDB) {
 
     for (const field of indexedFields) {
       const valueRepo = userRepo[field];
-      
+
       if (valueRepo == null) continue; // we do not expect to find null values in repo
 
       const isUnique = SystemStreamsSerializer.isUniqueAccountField(field);
@@ -61,7 +61,7 @@ module.exports = async function platformCheckIntegrity (platformWideDB) {
       }
       // all tests passed delete entry from platformEntryByUser
       delete platformEntryByUser[username][field];
-      // if user in platformEntryByUser is empty delete it 
+      // if user in platformEntryByUser is empty delete it
       if (Object.keys(platformEntryByUser[username]).length === 0) delete platformEntryByUser[username];
     }
   }
@@ -77,7 +77,7 @@ module.exports = async function platformCheckIntegrity (platformWideDB) {
     }
   }
   return {
-    title: 'plaformDb vs userReposity',
+    title: 'Platform DB vs users repository',
     infos,
     errors
   };

--- a/components/platform/src/service_register.js
+++ b/components/platform/src/service_register.js
@@ -27,7 +27,7 @@ type Operation = {
 
 const { getLogger, getConfig, notifyAirbrake } = require('@pryv/boiler');
 class ServiceRegister {
-  settings: null; 
+  settings: null;
   logger: {};
 
   constructor() {
@@ -37,7 +37,7 @@ class ServiceRegister {
 
   async init() {
     if (this.settings == null) {
-      this.settings = (await getConfig()).get('services:register')
+      this.settings = (await getConfig()).get('services:register');
       this.logger.debug('created with setttings:', this.settings);
     }
     return this;
@@ -56,7 +56,7 @@ class ServiceRegister {
       await superagent
         .post(url)
         .set('Authorization', this.settings.key)
-        .send({ 
+        .send({
           username: username,
           invitationToken: invitationToken,
           uniqueFields: uniqueFields,
@@ -106,7 +106,7 @@ class ServiceRegister {
       const res = await superagent
         .post(url)
         .set('Authorization', this.settings.key)
-        .send(user);     
+        .send(user);
       return res.body;
     } catch (err) {
       this.logger.error(err, err);
@@ -121,7 +121,7 @@ class ServiceRegister {
     try {
       const res = await superagent
         .delete(url)
-        .set('Authorization', this.settings.key);     
+        .set('Authorization', this.settings.key);
       return res.body;
     } catch (err) {
       this.logger.error(err, err);
@@ -173,7 +173,7 @@ class ServiceRegister {
       username,
       user: fieldsForUpdate,
       fieldsToDelete,
-    }
+    };
 
     try {
       const res = await superagent.put(url)
@@ -216,33 +216,33 @@ async function getServiceRegisterConn() {
   return serviceRegisterConn;
 }
 
- /**
-   * Temporary solution to patch a nasty bug, where "random" emails are exposed during account creations 
-   * @param {object} foundDuplicates the duplicates to check
-   * @param {string} username 
-   * @param {object} params 
-   */
-  function safetyCleanDuplicate(foundDuplicates, username, params: {}): {} {
-    if (foundDuplicates == null) return foundDuplicates;
-    const res: {} = {};
-    const newParams: {} = Object.assign({}, params);
-    if (username != null) newParams.username = username; 
-    for (const key of Object.keys(foundDuplicates)) {
-      if (foundDuplicates[key] === newParams[key]) {
-        res[key] = foundDuplicates[key] ;
-      } else {
-        notify(key + ' "' + foundDuplicates[key] + '" <> "' + newParams[key] + '"');
-      }
-    }
-    return res;
-
-    function notify(key) {
-      const logger = getLogger('service-register'); 
-      const error = new Error('Found unmatching duplicate key: ' + key);
-      logger.error('To be investigated >> ', error);
-      notifyAirbrake(error);
+/**
+ * Temporary solution to patch a nasty bug, where "random" emails are exposed during account creations
+ * @param {object} foundDuplicates the duplicates to check
+ * @param {string} username
+ * @param {object} params
+ */
+function safetyCleanDuplicate(foundDuplicates, username, params: {}): {} {
+  if (foundDuplicates == null) return foundDuplicates;
+  const res: {} = {};
+  const newParams: {} = Object.assign({}, params);
+  if (username != null) newParams.username = username;
+  for (const key of Object.keys(foundDuplicates)) {
+    if (foundDuplicates[key] === newParams[key]) {
+      res[key] = foundDuplicates[key] ;
+    } else {
+      notify(key + ' "' + foundDuplicates[key] + '" <> "' + newParams[key] + '"');
     }
   }
+  return res;
+
+  function notify(key) {
+    const logger = getLogger('service-register');
+    const error = new Error('Found unmatching duplicate key: ' + key);
+    logger.error('To be investigated >> ', error);
+    notifyAirbrake(error);
+  }
+}
 
 module.exports = {
   getServiceRegisterConn,

--- a/components/storage/src/localDataStore/localUserEvents.js
+++ b/components/storage/src/localDataStore/localUserEvents.js
@@ -62,7 +62,7 @@ module.exports = (ds.createUserEvents({
       toInsert.userId = userId;
       toInsert._id = event.id;
       delete toInsert.id;
-      const res =  await this.eventsCollection.insertOne(toInsert, options);
+      await this.eventsCollection.insertOne(toInsert, options);
       return event;
     } catch (err) {
       handleDuplicateError(err);
@@ -101,7 +101,7 @@ module.exports = (ds.createUserEvents({
       const options = {transactionSession: transaction?.transactionSession };
 
       const res = await this.eventsCollection.replaceOne(query, update, options);
-      const res2 = await this.eventsCollection.findOne({userId: userId, _id: update._id});
+      await this.eventsCollection.findOne({userId: userId, _id: update._id});
       return (res.modifiedCount === 1); // true if an event was updated
     } catch (err) {
       throw errors.unexpectedError(err);
@@ -166,26 +166,26 @@ function cleanResult(result) {
 const converters = {
   equal: (content) => {
     const realfield = (content.field === 'id') ? '_id' : content.field;
-    return {[realfield]: {$eq : content.value}}
+    return {[realfield]: {$eq : content.value}};
   },
   greater: (content) => {
-    return {[content.field]: {$gt :content.value}}
+    return {[content.field]: {$gt :content.value}};
   },
   greaterOrEqual: (content) => {
-    return {[content.field]: {$gte :content.value}}
+    return {[content.field]: {$gte :content.value}};
   },
   lowerOrEqual: (content) => {
-    return {[content.field]: {$lte :content.value}}
+    return {[content.field]: {$lte :content.value}};
   },
   greaterOrEqualOrNull: (content) => {
     return { $or: [{ [content.field]: { $gte: content.value } }, { [content.field]: null }] }
   },
   typesList: (list) => {
     if (list.length == 0) return null;
-    return {type: {$in: list.map(getTypeQueryValue)}}
+    return {type: {$in: list.map(getTypeQueryValue)}};
   },
   streamsQuery: (content) => {
-    return streamsQueryUtils.toMongoDBQuery(content)
+    return streamsQueryUtils.toMongoDBQuery(content);
   }
 };
 

--- a/components/test-helpers/src/database_fixture.js
+++ b/components/test-helpers/src/database_fixture.js
@@ -17,9 +17,7 @@ const _ = require('lodash');
 const storage = require('storage');
 
 const Webhook = require('business').webhooks.Webhook;
-const SystemStreamsSerializer = require('business/src/system-streams/serializer');
 const { getUsersRepository, User } = require('business/src/users');
-const usersIndex = require('business/src/users/UsersLocalIndex');
 const integrityFinalCheck = require('test-helpers/src/integrity-final-check');
 
 const { getMall } = require('mall');
@@ -43,9 +41,9 @@ class Context {
   }
 
   async cleanEverything (): Promise<mixed> {
-    const collectionNames = ['accesses', 'sessions', 'followedSlices', 'webhooks', 'versions']
-    const collections = collectionNames.map(collectionName => {
-      return bluebird.fromCallback(cb => this.databaseConn.deleteMany({ name: collectionName }, {}, cb))
+    const collectionNames = ['accesses', 'sessions', 'followedSlices', 'webhooks', 'versions'];
+    collectionNames.forEach(collectionName => {
+      bluebird.fromCallback(cb => this.databaseConn.deleteMany({ name: collectionName }, {}, cb));
     });
     const usersRepository = await getUsersRepository();
     await usersRepository.deleteAll();
@@ -121,8 +119,6 @@ class GenericChildHolder<T: ChildResource> {
   // (if given) needs to be of the same type, subclass of T.
   //
   create<U: T>(resource: U, cb?: (U) => mixed): Promise<U> {
-    const name = resource.constructor.name;
-
     const createdResource = resource.create();
     this.pending.push(createdResource);
 
@@ -296,7 +292,6 @@ class FixtureUser extends FixtureTreeNode implements ChildResource {
   }
 
   async createUser (): Object<mixed> {
-    const db = this.db;
     const attributes = this.attrs;
     const usersRepository = await getUsersRepository();
     const userObj: User = new User(attributes);
@@ -306,7 +301,6 @@ class FixtureUser extends FixtureTreeNode implements ChildResource {
 
   async remove(): Promise<mixed> {
     const db = this.db;
-    const user = null; // NOTE not needed for access to users collection.
     const username = this.context.userName;
     const collections = [
       db.accesses,
@@ -318,8 +312,7 @@ class FixtureUser extends FixtureTreeNode implements ChildResource {
     //const removeUser = bluebird.fromCallback((cb) =>
     //  db.users.removeOne(user, {username: username}, cb));
     // get streams ids from the config that should be deleted
-    const accountStreams = SystemStreamsSerializer.getAccountMap();
-
+    // const accountStreams = SystemStreamsSerializer.getAccountMap();
 
     const usersRepository = await getUsersRepository();
     await usersRepository.deleteOne(this.context.user.id, username, true);
@@ -379,7 +372,6 @@ class FixtureStream extends FixtureTreeNode implements ChildResource {
    * @returns {Promise<mixed>}
    */
   create() {
-    const db = this.db;
     const user = this.context.user;
     const attributes = this.attrs;
 
@@ -410,7 +402,6 @@ class FixtureEvent extends FixtureTreeNode implements ChildResource {
       .try(async () => await this.createEvent());
   }
   async createEvent() {
-    const db = this.db;
     const user = this.context.user;
     const attributes = this.attrs;
     if (mall == null) mall = await getMall();

--- a/justfile
+++ b/justfile
@@ -126,6 +126,14 @@ trace:
 test-data command version:
     NODE_ENV=development node dist/components/test-helpers/scripts/{{command}}-test-data {{version}}
 
+# Cleanup users data and MongoDB data in `var-pryv/`
+clean-data:
+    yes | rm -rf ./var-pryv/users/*
+    killall mongod
+    sleep 2
+    yes | rm -rf ./var-pryv/mongodb-data/*
+    ./scripts/start-mongo
+
 # –––––––––––––----------------------------------------------------------------
 # Misc. utils
 # –––––––––––––----------------------------------------------------------------
@@ -145,11 +153,3 @@ license:
 # Set version on all 'package.json' (root’s and components’)
 version version:
     npm version --no-git-tag-version --workspaces --include-workspace-root {{version}}
-
-# Cleanup var-pryv data and reset mongoddb data
-clean-data:
-    yes | rm -rf ./var-pryv/users/*
-    killall mongod 
-    sleep 2
-    yes | rm -rf ./var-pryv/mongodb-data/* 
-    ./scripts/start-mongo


### PR DESCRIPTION
This fix works was done by adding an integrity test before and after each test to evaluate the states of the db. 
It resulted in finding small discrepencies. 
These hook might be kept for long term (if not too time costly)