### PR TITLE
Fix crash in migration #490

### DIFF
--- a/components/storage/src/migrations/1.7.0.js
+++ b/components/storage/src/migrations/1.7.0.js
@@ -72,7 +72,12 @@ module.exports = async function (context, callback) {
           }
         }
       };
-      if (isUniqueEvent(event.streamIds)) { request.updateOne.update.$unset = buildUniquePropsToDelete(event); }
+      if (isUniqueEvent(event.streamIds)) {
+        request.updateOne.update.$unset = buildUniquePropsToDelete(event);
+      }
+      if (request.updateOne.update.$unset != null && Object.keys(request.updateOne.update.$unset).length === 0) {
+        delete request.updateOne.update.$unset; // happend on partially migrated items.
+      }
       // console.log('translated to', JSON.stringify(request,null,2));
       requests.push(request);
       if (requests.length > BUFFER_SIZE) { requests = await flushToDb(requests, eventsCollection); }


### PR DESCRIPTION
Check ticket for more context https://pryvhelp.zendesk.com/agent/tickets/1524

The bug is caused by an event with a unique property "null" in 1.6.0 design. 
The fix prevent the migration to crash, but the "cause" has not been found. 